### PR TITLE
Create deploy-pages.yml

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -32,7 +32,7 @@ jobs:
           pip install -r scripts/requirements.txt
 
       - name: Validate repository
-        run: scripts/validate-repo.sh
+        run: bash scripts/validate-repo.sh
 
       - name: Build static site
         run: |

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,58 @@
+name: Deploy Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install automation requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r scripts/requirements.txt
+
+      - name: Validate repository
+        run: scripts/validate-repo.sh
+
+      - name: Build static site
+        run: |
+          mkdir -p site
+          cp -R docs/. site/
+          mkdir -p site/catalog
+          cp -R catalog/. site/catalog/
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that validates the repository scaffold and publishes the Pages site via the official Pages deployment actions
- copy the static docs and catalog assets into a dedicated `site/` artifact so future generators or transformations can be layered in without touching `main`
- ensure the workflow runs on pushes to `main` and when triggered manually, keeping catalog publishing predictable

## Testing
- workflow is configuration only; verified expected steps locally (`scripts/validate-repo.sh`) before composing the action

