### PR TITLE
Set up MkDocs site build for Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -36,8 +36,7 @@ jobs:
 
       - name: Build static site
         run: |
-          mkdir -p site
-          cp -R docs/. site/
+          mkdocs build --strict --clean --site-dir site
           mkdir -p site/catalog
           cp -R catalog/. site/catalog/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# Agent Guidelines
+
+Welcome! Please follow these conventions whenever you modify files in this repository.
+
+## Repository-wide expectations
+- Prefer small, focused commits with descriptive messages.
+- Keep documentation in Markdown unless a build step requires HTML output.
+- When touching automation under `.github/workflows/`, preserve existing job names and required permissions.
+
+## Required checks
+Before opening a pull request or concluding work in this environment, run the following commands from the repository root and ensure they succeed:
+
+```bash
+scripts/validate-repo.sh
+mkdocs build --strict --clean --site-dir site
+```
+
+These checks keep the catalog metadata synchronized and confirm the documentation site builds without warnings. If you add new automated checks, update this list accordingly.
+
+## Documentation style
+- Organize new documentation under `docs/` and include it in the MkDocs navigation (`mkdocs.yml`) when appropriate.
+- Use relative links between documentation pages; avoid hard-coding absolute GitHub URLs unless necessary.
+- Favor sentence case for headings and keep introductory paragraphs short and action-oriented.
+
+Thanks for helping maintain the SRE Toolbox community catalog!

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,8 +9,8 @@ Welcome to the public landing page for the SRE Toolbox community repository. Thi
 ## Explore the catalog
 
 - [Sample Diagnostics Toolkit](sample-toolkit/)
-- [Download the machine-readable catalog](https://raw.githubusercontent.com/{{ site.github.owner_name }}/{{ site.github.repository_name }}/main/catalog/toolkits.json)
-- [Browse the repository on GitHub]({{ site.github.repository_url }})
+- [Download the machine-readable catalog]({{ raw_catalog_url }})
+- [Browse the repository on GitHub]({{ repo_url }})
 
 ## Documentation for contributors
 
@@ -29,4 +29,4 @@ scripts/validate-repo.sh
 scripts/package-toolkit.sh <slug>
 ```
 
-See the [scripts directory]({{ site.github.repository_url }}/tree/main/scripts) for additional helpers and usage details.
+See the [scripts directory]({{ repo_url }}/tree/main/scripts) for additional helpers and usage details.

--- a/macros.py
+++ b/macros.py
@@ -1,0 +1,18 @@
+"""Macros for MkDocs builds."""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+DEFAULT_REPO_SLUG = "sre-toolbox-community/ideal-octo-engine"
+
+
+def define_env(env: Any) -> None:
+    """Register template variables available to Markdown pages."""
+    repo_slug = os.environ.get("GITHUB_REPOSITORY", DEFAULT_REPO_SLUG)
+    env.variables["repo_slug"] = repo_slug
+    env.variables["repo_url"] = f"https://github.com/{repo_slug}"
+    env.variables["raw_catalog_url"] = (
+        f"https://raw.githubusercontent.com/{repo_slug}/main/catalog/toolkits.json"
+    )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,33 @@
+site_name: SRE Toolbox Community Catalog
+site_description: Community-managed toolkit registry for the Toolbox framework.
+repo_url: https://github.com/sre-toolbox-community/ideal-octo-engine
+site_dir: site
+use_directory_urls: true
+
+nav:
+  - Home: index.md
+  - Documentation:
+      - Repository structure: structure.md
+      - Changelog: changelog.md
+      - Toolkit authoring:
+          - Getting started: toolkit-authoring/getting-started.md
+          - Packaging checklist: toolkit-authoring/packaging.md
+      - Governance:
+          - Contribution process: governance/contribution-process.md
+          - Security review: governance/security-review.md
+          - Decision log: governance/decision-log.md
+      - Sample toolkit: sample-toolkit/index.md
+
+plugins:
+  - search
+  - macros
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,7 +20,9 @@ nav:
 
 plugins:
   - search
-  - macros
+  - macros:
+      modules:
+        - macros
 
 markdown_extensions:
   - admonition

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,2 +1,3 @@
 # Python requirements for repository automation
-# (Only standard library modules are required today; pin packages here as they are introduced.)
+mkdocs>=1.5
+mkdocs-macros-plugin>=1.0


### PR DESCRIPTION
## Summary
- add repository guidance for future contributors in `AGENTS.md`
- configure MkDocs (with macros) so the documentation site compiles to HTML
- update the Pages workflow to build the MkDocs site and publish the catalog assets

## Testing
- scripts/validate-repo.sh
- mkdocs build --strict --clean --site-dir site *(fails locally: mkdocs not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d097005944832889f1a7e9337dc853