### PR TITLE
Fix MkDocs macros module name

### DIFF
--- a/catalog_macros/__init__.py
+++ b/catalog_macros/__init__.py
@@ -1,11 +1,11 @@
 """Runtime helpers for the MkDocs macros plugin.
 
 The deploy workflow invokes ``mkdocs build`` with the `mkdocs-macros` plugin
-enabled.  The plugin imports this module and looks for a ``define_env``
-function.  If the function is missing, the build fails with the same error that
-triggered the current task.  Keeping this implementation small and dependency
-free helps ensure the documentation site can be generated inside the CI
-environment without additional bootstrap steps.
+enabled.  The plugin imports :mod:`catalog_macros` and looks for a
+``define_env`` function.  If the function is missing, the build fails with the
+same error that triggered the current task.  Keeping this implementation small
+and dependency free helps ensure the documentation site can be generated inside
+the CI environment without additional bootstrap steps.
 """
 from __future__ import annotations
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,7 +22,7 @@ plugins:
   - search
   - macros:
       modules:
-        - macros
+        - catalog_macros
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary
- rename the MkDocs macros helper module to `catalog_macros` to avoid conflicts with the similarly named package on PyPI
- update the macros documentation helper to reflect the new module name and keep the exported API unchanged
- point MkDocs at the renamed module so the build can load the expected `define_env` hook

## Testing
- scripts/validate-repo.sh
- mkdocs build --strict --clean --site-dir site *(fails locally: mkdocs not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d09cc629f483288fe8434f68d0b770