### PR TITLE
Fix MkDocs macros import in local builds

### DIFF
--- a/macros/main.py
+++ b/macros/main.py
@@ -1,11 +1,10 @@
 """Runtime helpers for the MkDocs macros plugin.
 
-The deploy workflow invokes ``mkdocs build`` with the `mkdocs-macros` plugin
-enabled.  The plugin imports :mod:`catalog_macros` and looks for a
-``define_env`` function.  If the function is missing, the build fails with the
-same error that triggered the current task.  Keeping this implementation small
-and dependency free helps ensure the documentation site can be generated inside
-the CI environment without additional bootstrap steps.
+The documentation site relies on ``mkdocs-macros-plugin`` to expose a handful
+of repository-specific variables to Markdown pages.  When the plugin is loaded
+it imports this module and invokes :func:`define_env`.  Keeping the
+implementation dependency free ensures the documentation site can be generated
+in CI environments without any additional bootstrap steps.
 """
 from __future__ import annotations
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,9 +20,7 @@ nav:
 
 plugins:
   - search
-  - macros:
-      modules:
-        - catalog_macros
+  - macros
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary
- move the MkDocs macros helpers into the default `macros/main.py` location so the plugin loads them without pip installing
- simplify the MkDocs configuration to rely on the plugin’s default module discovery

## Testing
- scripts/validate-repo.sh
- mkdocs build --strict --clean --site-dir site *(fails: mkdocs not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d09e2894b88328a08f87318bfb06a1