### PR TITLE
Fix documentation link macros and test docs build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,23 @@ jobs:
       - name: Validate repository
         run: |
           scripts/validate-repo.sh
+  docs-build:
+    runs-on: ubuntu-latest
+    needs: validate
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r scripts/requirements.txt
+      - name: Build documentation
+        run: |
+          mkdocs build --strict --clean --site-dir site
+          mkdir -p site/catalog
+          cp -R catalog/. site/catalog/
   package-sample-toolkit:
     runs-on: ubuntu-latest
     steps:

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ Welcome to the public landing page for the SRE Toolbox community repository. Thi
 
 ## Explore the catalog
 
-- [Sample Diagnostics Toolkit](sample-toolkit/)
+- [Sample Diagnostics Toolkit](sample-toolkit/index.md)
 - [Download the machine-readable catalog]({{ raw_catalog_url }})
 - [Browse the repository on GitHub]({{ repo_url }})
 

--- a/docs/sample-toolkit/index.md
+++ b/docs/sample-toolkit/index.md
@@ -22,7 +22,7 @@ The Sample Diagnostics Toolkit acts as a reference implementation for community 
 3. Upload the generated zip (`dist/sample-toolkit-<date>.zip`) through the Toolbox Admin → Toolkits UI.
 4. Verify the `/toolkits/sample/health` endpoint returns HTTP 200 with status `ok`.
 
-The toolkit manifest is available at [`toolkits/sample-toolkit/toolkit.json`]({{ site.github.repository_url }}/blob/main/toolkits/sample-toolkit/toolkit.json).
+The toolkit manifest is available at [`toolkits/sample-toolkit/toolkit.json`]({{ repo_url }}/blob/main/toolkits/sample-toolkit/toolkit.json).
 
 ## Maintenance
 

--- a/macros/__init__.py
+++ b/macros/__init__.py
@@ -1,0 +1,1 @@
+"""MkDocs macros package."""

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,7 +20,8 @@ nav:
 
 plugins:
   - search
-  - macros
+  - macros:
+      module_name: macros.main
 
 markdown_extensions:
   - admonition

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,7 +21,7 @@ nav:
 plugins:
   - search
   - macros:
-      module_name: macros.main
+      module_name: macros/main
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary
- replace the sample toolkit manifest link to use the existing mkdocs macro variables and fix the home page link
- add a docs-build job to CI that reproduces the deploy build steps so pull requests verify the static site build

## Testing
- scripts/validate-repo.sh
- mkdocs build --strict --clean --site-dir site *(fails: mkdocs command unavailable in container due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_68d0ab6b86208328bf165ed57ffb31b1