### PR TITLE
Add toolkit browser and clarify contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,13 @@ Thanks for your interest in contributing! This guide describes how to propose to
 2. **Fork & branch** – Create a topic branch in your fork (`toolkit/<slug>-<change>`).
 3. **Develop test-first** – Add or update tests and validation scripts before making behavioural changes.
 4. **Validate** – Run `scripts/validate-toolkit.sh` (or the relevant automation) and capture output in your PR description.
-5. **Document** – Update README files, changelogs, or catalog metadata as needed.
+5. **Document** – Update README files, changelogs, and catalog metadata as needed.
+   - Keep `toolkits/<slug>/README.md` current; reviewers treat it as the
+     canonical install guide.
+   - Create a documentation landing page at `docs/<slug>/index.md` (copy
+     `docs/sample-toolkit/index.md` as a template) and add it to `mkdocs.yml`.
+   - Update `catalog/toolkits.json` with `docs_url`, `categories`, and other
+     metadata so the browse experience lists your submission.
 6. **Submit** – Open a PR using the template in `.github/PULL_REQUEST_TEMPLATE.md`.
 7. **Review** – Address reviewer feedback promptly. Maintainers will verify packaging, security expectations, and documentation coverage.
 
@@ -23,7 +29,11 @@ Thanks for your interest in contributing! This guide describes how to propose to
 - [ ] Toolkit directory follows `toolkits/<slug>/` layout with `toolkit.json` and optional runtime modules.
 - [ ] Bundle builds with `scripts/package-toolkit.sh <slug>`.
 - [ ] Toolkit metadata appears in `catalog/toolkits.json` with accurate version and tags.
+- [ ] Catalog entry includes `docs_url` (e.g. `"<slug>/"`) and at least one
+      `categories` value for the browse filters.
 - [ ] Documentation under `toolkits/<slug>/docs/` covers installation, configuration, and known limitations.
+- [ ] Public docs exist at `docs/<slug>/index.md` and are linked from the
+      MkDocs navigation.
 - [ ] Security review questionnaire (`docs/governance/security-review.md`) is attached to the PR.
 
 ## Coding standards

--- a/catalog/toolkits.json
+++ b/catalog/toolkits.json
@@ -10,7 +10,8 @@
       "tags": ["sample", "diagnostics", "reference"],
       "maintainers": ["toolbox-maintainers@example.com"],
       "source": "toolkits/sample-toolkit",
-      "docs_url": "docs/sample-toolkit/index.html"
+      "docs_url": "sample-toolkit/",
+      "categories": ["Diagnostics", "Examples"]
     }
   ]
 }

--- a/docs/catalog/browse.md
+++ b/docs/catalog/browse.md
@@ -1,0 +1,496 @@
+---
+title: Browse toolkits
+---
+
+# Browse community toolkits
+
+Use the interactive catalog below to search, filter, and discover published
+SRE Toolbox toolkits. Results come directly from the
+[`catalog/toolkits.json`]({{ repo_url }}/blob/main/catalog/toolkits.json)
+metadata file, so updates are reflected as soon as a pull request is merged.
+
+- **Search** by name, description, tags, or maintainer.
+- **Filter** by category to narrow the list to similar toolkits.
+- **Open** the documentation or source repository with a single click.
+
+<style>
+.toolkit-browser {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.toolkit-browser__controls {
+  display: grid;
+  gap: 0.5rem;
+  max-width: 32rem;
+}
+
+.toolkit-browser__controls input[type="search"] {
+  padding: 0.5rem 0.75rem;
+  font-size: 1rem;
+}
+
+.toolkit-browser__category-group {
+  border: 1px solid var(--md-default-fg-color--lightest, #ccc);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.5rem;
+  align-items: center;
+}
+
+.toolkit-browser__category {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.toolkit-browser__clear {
+  margin-left: auto;
+  padding: 0.35rem 0.75rem;
+  border: 1px solid var(--md-accent-fg-color, #3f51b5);
+  border-radius: 9999px;
+  background: transparent;
+  color: var(--md-accent-fg-color, #3f51b5);
+  cursor: pointer;
+}
+
+.toolkit-browser__results {
+  display: grid;
+  gap: 1rem;
+}
+
+.toolkit-browser__card {
+  border: 1px solid var(--md-default-fg-color--lightest, #ccc);
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.04);
+}
+
+.toolkit-browser__card h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.toolkit-browser__meta {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.25rem 0.75rem;
+  margin: 0.75rem 0;
+}
+
+.toolkit-browser__meta dt {
+  font-weight: 600;
+}
+
+.toolkit-browser__meta dd {
+  margin: 0;
+}
+
+.toolkit-browser__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  list-style: none;
+  padding: 0;
+  margin: 0.75rem 0;
+}
+
+.toolkit-browser__tags li {
+  background: var(--md-default-fg-color--lightest, #e8e8e8);
+  border-radius: 9999px;
+  padding: 0.2rem 0.75rem;
+  font-size: 0.85rem;
+}
+
+.toolkit-browser__links {
+  margin: 0.75rem 0 0;
+}
+
+.toolkit-browser__status {
+  margin: 0;
+  font-weight: 600;
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (min-width: 48rem) {
+  .toolkit-browser__results {
+    grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+  }
+}
+</style>
+
+<div class="toolkit-browser" data-role="toolkit-browser">
+  <form class="toolkit-browser__controls" aria-label="Toolkit filters">
+    <label for="toolkit-search">Search the catalog</label>
+    <input
+      type="search"
+      id="toolkit-search"
+      name="toolkit-search"
+      placeholder="Search by name, description, maintainer, or tag"
+      autocomplete="off"
+      data-role="toolkit-search"
+    />
+  </form>
+  <section class="toolkit-browser__categories" aria-live="polite">
+    <h2 class="visually-hidden">Categories</h2>
+    <div data-role="toolkit-categories"></div>
+  </section>
+  <p class="toolkit-browser__status" data-role="toolkit-status" aria-live="polite"></p>
+  <div class="toolkit-browser__results" data-role="toolkit-results" role="list"></div>
+</div>
+
+<noscript>
+  JavaScript is required to render the interactive catalog. You can still
+  download the <a href="{{ raw_catalog_url }}">machine-readable index</a> or
+  browse the repository on <a href="{{ repo_url }}">GitHub</a>.
+</noscript>
+
+<script>
+(() => {
+  'use strict';
+
+  const DATA_URL = '{{ raw_catalog_url }}';
+  const REPO_URL = '{{ repo_url }}';
+
+  const SITE_ROOT = (() => {
+    const marker = '/catalog/';
+    const path = window.location.pathname || '/';
+    if (path.includes(marker)) {
+      const prefix = path.split(marker)[0];
+      if (!prefix || prefix === '/') {
+        return '/';
+      }
+      return prefix.endsWith('/') ? prefix : `${prefix}/`;
+    }
+    if (path.endsWith('/')) {
+      return path;
+    }
+    const segments = path.split('/');
+    segments.pop();
+    return `${segments.join('/')}/`;
+  })();
+
+  function resolveDocsUrl(value) {
+    if (!value) {
+      return new URL(SITE_ROOT, window.location.origin).toString();
+    }
+    if (/^https?:/i.test(value)) {
+      return value;
+    }
+    if (value.startsWith('./') || value.startsWith('../')) {
+      return new URL(value, window.location.href).toString();
+    }
+    const cleaned = value.replace(/^\/+/g, '');
+    return new URL(cleaned, `${window.location.origin}${SITE_ROOT}`).toString();
+  }
+
+  function resolveSourceUrl(value) {
+    if (!value) {
+      return '';
+    }
+    if (/^https?:/i.test(value)) {
+      return value;
+    }
+    const cleaned = value.replace(/^\/+/g, '');
+    return `${REPO_URL}/tree/main/${cleaned}`;
+  }
+
+  const browserRoot = document.querySelector('[data-role="toolkit-browser"]');
+  if (!browserRoot) {
+    return;
+  }
+
+  const searchInput = browserRoot.querySelector('[data-role="toolkit-search"]');
+  const categoryContainer = browserRoot.querySelector('[data-role="toolkit-categories"]');
+  const statusRegion = browserRoot.querySelector('[data-role="toolkit-status"]');
+  const resultsRegion = browserRoot.querySelector('[data-role="toolkit-results"]');
+
+  const state = {
+    toolkits: [],
+    categories: new Map(),
+    activeCategories: new Set(),
+    query: ''
+  };
+
+  function normalise(value) {
+    return (value || '').toString().trim().toLowerCase();
+  }
+
+  function buildCategories(toolkits) {
+    state.categories.clear();
+    toolkits.forEach((toolkit) => {
+      const rawCategories = Array.isArray(toolkit.categories) && toolkit.categories.length
+        ? toolkit.categories
+        : toolkit.tags || [];
+      rawCategories.forEach((label) => {
+        const key = normalise(label);
+        if (!key) {
+          return;
+        }
+        if (!state.categories.has(key)) {
+          state.categories.set(key, label);
+        }
+      });
+    });
+  }
+
+  function renderCategories() {
+    if (!categoryContainer) {
+      return;
+    }
+    categoryContainer.innerHTML = '';
+    const categories = Array.from(state.categories.entries())
+      .sort((a, b) => a[1].localeCompare(b[1]));
+    if (!categories.length) {
+      return;
+    }
+
+    const list = document.createElement('fieldset');
+    list.className = 'toolkit-browser__category-group';
+    const legend = document.createElement('legend');
+    legend.textContent = 'Filter by category';
+    list.appendChild(legend);
+
+    categories.forEach(([key, label]) => {
+      const wrapper = document.createElement('label');
+      wrapper.className = 'toolkit-browser__category';
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      checkbox.value = key;
+      checkbox.checked = state.activeCategories.has(key);
+      checkbox.addEventListener('change', () => {
+        if (checkbox.checked) {
+          state.activeCategories.add(key);
+        } else {
+          state.activeCategories.delete(key);
+        }
+        renderResults();
+      });
+
+      const span = document.createElement('span');
+      span.textContent = label;
+      wrapper.appendChild(checkbox);
+      wrapper.appendChild(span);
+      list.appendChild(wrapper);
+    });
+
+    const clearButton = document.createElement('button');
+    clearButton.type = 'button';
+    clearButton.className = 'toolkit-browser__clear';
+    clearButton.textContent = 'Clear categories';
+    clearButton.addEventListener('click', () => {
+      state.activeCategories.clear();
+      renderCategories();
+      renderResults();
+    });
+    list.appendChild(clearButton);
+
+    categoryContainer.appendChild(list);
+  }
+
+  function matchesQuery(toolkit, query) {
+    if (!query) {
+      return true;
+    }
+    const haystack = [
+      toolkit.name,
+      toolkit.description,
+      (toolkit.tags || []).join(' '),
+      (toolkit.maintainers || []).join(' ')
+    ].map(normalise).join(' ');
+    return haystack.includes(query);
+  }
+
+  function matchesCategory(toolkit) {
+    if (!state.activeCategories.size) {
+      return true;
+    }
+    const values = new Set(
+      ((toolkit.categories && toolkit.categories.length ? toolkit.categories : toolkit.tags) || [])
+        .map(normalise)
+    );
+    for (const key of state.activeCategories) {
+      if (values.has(key)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function buildToolkitCard(toolkit) {
+    const article = document.createElement('article');
+    article.className = 'toolkit-browser__card';
+    article.setAttribute('role', 'listitem');
+
+    const heading = document.createElement('h3');
+    const docsLink = document.createElement('a');
+    docsLink.href = toolkit.docs_url;
+    docsLink.textContent = toolkit.name;
+    heading.appendChild(docsLink);
+    article.appendChild(heading);
+
+    const description = document.createElement('p');
+    description.textContent = toolkit.description;
+    article.appendChild(description);
+
+    const metaList = document.createElement('dl');
+    metaList.className = 'toolkit-browser__meta';
+
+    const versionTerm = document.createElement('dt');
+    versionTerm.textContent = 'Version';
+    const versionValue = document.createElement('dd');
+    versionValue.textContent = toolkit.version;
+    metaList.appendChild(versionTerm);
+    metaList.appendChild(versionValue);
+
+    if (toolkit.maintainers && toolkit.maintainers.length) {
+      const maintainerTerm = document.createElement('dt');
+      maintainerTerm.textContent = 'Maintainers';
+      const maintainerValue = document.createElement('dd');
+      maintainerValue.textContent = toolkit.maintainers.join(', ');
+      metaList.appendChild(maintainerTerm);
+      metaList.appendChild(maintainerValue);
+    }
+
+    article.appendChild(metaList);
+
+    if (toolkit.tags && toolkit.tags.length) {
+      const tagList = document.createElement('ul');
+      tagList.className = 'toolkit-browser__tags';
+      toolkit.tags.forEach((tag) => {
+        const item = document.createElement('li');
+        item.textContent = tag;
+        tagList.appendChild(item);
+      });
+      article.appendChild(tagList);
+    }
+
+    const links = document.createElement('p');
+    links.className = 'toolkit-browser__links';
+
+    const docsAnchor = document.createElement('a');
+    docsAnchor.href = toolkit.docs_url;
+    docsAnchor.textContent = 'View documentation';
+    links.appendChild(docsAnchor);
+
+    if (toolkit.source_url) {
+      links.appendChild(document.createTextNode(' · '));
+      const sourceAnchor = document.createElement('a');
+      sourceAnchor.href = toolkit.source_url;
+      sourceAnchor.textContent = 'View source';
+      links.appendChild(sourceAnchor);
+    }
+
+    article.appendChild(links);
+    return article;
+  }
+
+  function renderResults() {
+    if (!resultsRegion) {
+      return;
+    }
+    const query = normalise(state.query);
+    const filtered = state.toolkits
+      .filter((toolkit) => matchesQuery(toolkit, query))
+      .filter((toolkit) => matchesCategory(toolkit));
+
+    resultsRegion.innerHTML = '';
+    if (statusRegion) {
+      statusRegion.textContent = filtered.length
+        ? `${filtered.length} toolkit${filtered.length === 1 ? '' : 's'} found`
+        : 'No toolkits match the current filters.';
+    }
+
+    if (!filtered.length) {
+      const emptyMessage = document.createElement('p');
+      emptyMessage.textContent = 'Try adjusting your search terms or clearing filters to see more toolkits.';
+      resultsRegion.appendChild(emptyMessage);
+      return;
+    }
+
+    filtered
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .forEach((toolkit) => {
+        resultsRegion.appendChild(buildToolkitCard(toolkit));
+      });
+  }
+
+  function prepareToolkit(rawToolkit) {
+    const docsUrl = rawToolkit.docs_url || `${rawToolkit.slug || ''}/`;
+    const source = rawToolkit.source_url
+      ? resolveSourceUrl(rawToolkit.source_url)
+      : resolveSourceUrl(rawToolkit.source);
+
+    return {
+      ...rawToolkit,
+      docs_url: resolveDocsUrl(docsUrl),
+      source_url: source
+    };
+  }
+
+  function handleSearch(event) {
+    state.query = event.target.value;
+    renderResults();
+  }
+
+  if (searchInput) {
+    searchInput.addEventListener('input', handleSearch);
+  }
+
+  fetch(DATA_URL)
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`Failed to load catalog: ${response.status}`);
+      }
+      return response.json();
+    })
+    .then((payload) => {
+      const toolkits = Array.isArray(payload.toolkits) ? payload.toolkits : [];
+      state.toolkits = toolkits.map(prepareToolkit);
+      buildCategories(state.toolkits);
+      renderCategories();
+      renderResults();
+    })
+    .catch((error) => {
+      if (statusRegion) {
+        statusRegion.textContent = 'Unable to load the toolkit catalog. Please try again later or download the catalog JSON.';
+      }
+      if (resultsRegion) {
+        const fallback = document.createElement('p');
+        fallback.textContent = error.message;
+        resultsRegion.appendChild(fallback);
+      }
+    });
+})();
+</script>
+
+## Add your toolkit to the browser
+
+Each toolkit entry is sourced from `catalog/toolkits.json`. To ensure your
+submission appears here:
+
+1. Add or update the catalog entry with an accurate `name`, `description`,
+   `version`, and a list of `tags`.
+2. Include a `categories` array to group the toolkit with similar solutions.
+   Categories appear in the filter list above.
+3. Set `docs_url` to the published documentation page (for example,
+   `"my-toolkit/"`). The path should resolve within this documentation site.
+4. Provide either a `source_url` or `source` path so the browser can link to
+   the implementation.
+
+Refer to the [packaging guide](../toolkit-authoring/packaging.md) for a complete
+walkthrough of the catalog update workflow.

--- a/docs/governance/contribution-process.md
+++ b/docs/governance/contribution-process.md
@@ -13,10 +13,19 @@ This repository maintains the public catalog of SRE Toolbox toolkits. The proces
 1. **Proposal** – Contributor opens an issue or discussion describing the toolkit, target use cases, and dependencies.
 2. **Implementation** – Contributor develops the toolkit in a fork, following `docs/toolkit-authoring/` guidance and adding documentation.
 3. **Validation** – Contributor runs `scripts/validate-toolkit.sh <slug>` and shares results, along with manual test notes.
-4. **Pull request** – Contributor submits a PR using `.github/PULL_REQUEST_TEMPLATE.md`, attaches the packaged bundle, and includes the security questionnaire.
+4. **Pull request** – Contributor submits a PR using `.github/PULL_REQUEST_TEMPLATE.md`, attaches the packaged bundle, and includes the security questionnaire. The PR must also:
+   - Publish a documentation page at `docs/<slug>/index.md` (copy the sample toolkit page as a starting point) and add it to `mkdocs.yml`.
+   - Update `catalog/toolkits.json` with accurate metadata, including `docs_url` and relevant `categories` for the browse experience.
 5. **Review** – Maintainers perform code review, run validation scripts, and request adjustments as needed. Security reviewer signs off when required.
-6. **Catalog update** – Once approved, maintainers merge the PR, regenerate catalog metadata if necessary, and publish the bundle to GitHub Releases.
+6. **Catalog update** – Once approved, maintainers merge the PR, regenerate catalog metadata if necessary, verify the browse interface lists the toolkit, and publish the bundle to GitHub Releases.
 7. **Announcement** – Maintainers update `docs/changelog.md` and share availability through community channels.
+
+## Documentation expectations
+
+- Treat `toolkits/<slug>/README.md` as the authoritative installation and operations guide. It should mirror what operators see after downloading the bundle.
+- Mirror the README highlights in a public documentation page at `docs/<slug>/index.md`. This page powers the catalog browser and should summarize features, installation steps, and maintenance notes.
+- Reference deeper runbooks or FAQs from `toolkits/<slug>/docs/` within the public page so users can drill into details without leaving the site.
+- Keep `catalog/toolkits.json` in sync with each release. Update `version`, `description`, `docs_url` (typically `"<slug>/"`), `tags`, and `categories` so the browse experience remains accurate.
 
 ## Service-level expectations
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ Welcome to the public landing page for the SRE Toolbox community repository. Thi
 
 ## Explore the catalog
 
+- [Browse all community toolkits](catalog/browse.md)
 - [Sample Diagnostics Toolkit](sample-toolkit/index.md)
 - [Download the machine-readable catalog]({{ raw_catalog_url }})
 - [Browse the repository on GitHub]({{ repo_url }})

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -14,6 +14,7 @@
 ## Key files
 
 - `catalog/toolkits.json` – Canonical metadata for all published toolkits.
+- `docs/catalog/` – Interactive catalog browser backed by the metadata file.
 - `docs/toolkit-authoring/` – Guides for building, testing, and shipping toolkits.
 - `docs/governance/` – Contribution workflow, review process, and security expectations.
 - `ai/ops/codex.md` – Maintainer automation prompt used by Codex agents.

--- a/docs/toolkit-authoring/getting-started.md
+++ b/docs/toolkit-authoring/getting-started.md
@@ -14,7 +14,7 @@ This guide helps you bootstrap a new toolkit for the SRE Toolbox community repos
 2. Copy `toolkits/sample-toolkit/` as a starting point (`cp -R sample-toolkit <your-slug>`).
 3. Update `toolkit.json` with your toolkit slug, name, version, and entry points.
 4. Implement backend, worker, and frontend modules as needed.
-5. Document configuration, runbooks, and limitations under `toolkits/<slug>/docs/`.
+5. Document configuration, runbooks, and limitations under `toolkits/<slug>/docs/`, and draft the public overview page at `docs/<slug>/index.md` so users can browse your toolkit without cloning the repository.
 6. Run `scripts/validate-toolkit.sh <slug>` and address any findings.
 7. Run integration tests within a Toolbox environment.
 8. Submit a PR with the checklist in `.github/PULL_REQUEST_TEMPLATE.md`.

--- a/docs/toolkit-authoring/packaging.md
+++ b/docs/toolkit-authoring/packaging.md
@@ -5,7 +5,7 @@ Once your toolkit implementation is ready, follow the steps below to bundle it f
 ## 1. Update metadata
 
 - Ensure `toolkits/<slug>/toolkit.json` is complete and versioned.
-- Add or update the corresponding entry in `catalog/toolkits.json` (keep entries sorted alphabetically by slug).
+- Add or update the corresponding entry in `catalog/toolkits.json` (keep entries sorted alphabetically by slug). Include `docs_url` (for example, `"<slug>/"`) and at least one `categories` value so the browse experience can surface your toolkit.
 - Provide changelog context in `docs/changelog.md` when releasing updates.
 
 ## 2. Validate locally
@@ -31,6 +31,7 @@ Attach the resulting zip to your pull request. Reviewers will attempt installati
 ## 4. Document the release
 
 - Update `toolkits/<slug>/README.md` with installation and configuration notes.
+- Publish a documentation landing page under `docs/<slug>/index.md` that summarizes key capabilities, installation steps, and maintenance expectations. The [sample toolkit page](../sample-toolkit/index.md) provides a copy-friendly template.
 - Provide operator-focused documentation under `toolkits/<slug>/docs/` (runbook, troubleshooting, FAQ).
 - Complete the security review questionnaire (`docs/governance/security-review.md`) and attach it to the PR.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,9 @@ use_directory_urls: true
 
 nav:
   - Home: index.md
+  - Catalog:
+      - Browse toolkits: catalog/browse.md
+      - Sample Diagnostics Toolkit: sample-toolkit/index.md
   - Documentation:
       - Repository structure: structure.md
       - Changelog: changelog.md
@@ -16,7 +19,6 @@ nav:
           - Contribution process: governance/contribution-process.md
           - Security review: governance/security-review.md
           - Decision log: governance/decision-log.md
-      - Sample toolkit: sample-toolkit/index.md
 
 plugins:
   - search

--- a/scripts/validate_catalog.py
+++ b/scripts/validate_catalog.py
@@ -31,10 +31,22 @@ def validate_entry(slug: str, entry: dict, *, strict: bool) -> list[str]:
         else:
             if manifest_data.get("slug") != slug:
                 issues.append(f"Manifest slug mismatch for {slug}")
-    required_fields = {"name", "version", "description", "tags"}
+    required_fields = {"name", "version", "description", "tags", "docs_url", "categories"}
     missing = required_fields - entry.keys()
     if missing:
         issues.append(f"Catalog entry for {slug} missing keys: {sorted(missing)}")
+    else:
+        if not isinstance(entry.get("docs_url"), str) or not entry["docs_url"].strip():
+            issues.append(f"Catalog entry for {slug} has an empty docs_url")
+        categories = entry.get("categories", [])
+        if not isinstance(categories, list) or not all(isinstance(item, str) and item.strip() for item in categories):
+            issues.append(
+                f"Catalog entry for {slug} must define categories as a list of non-empty strings"
+            )
+
+    doc_page = REPO_ROOT / "docs" / slug / "index.md"
+    if not doc_page.exists():
+        issues.append(f"Documentation page missing: docs/{slug}/index.md")
     return issues
 
 


### PR DESCRIPTION
## Summary
- add an interactive catalog browser with search, category filters, and navigation updates
- require toolkit catalog entries to declare docs URLs and categories, ensuring public docs exist for each slug
- expand contributor documentation to explain how toolkit pages feed the catalog browsing experience

## Testing
- scripts/validate-repo.sh
- mkdocs build --strict --clean --site-dir site

------
https://chatgpt.com/codex/tasks/task_b_68d0b316bc8c832889a24c34e9504649