### PR TITLE
Stop tracking generated toolkit bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Build artifacts
 /dist/
 
+# Generated toolkit bundles (created by sync_toolkit_assets.py)
+docs/toolkits/*/bundle.zip
+
+
 # Python
 __pycache__/
 *.pyc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,11 +16,9 @@ Thanks for your interest in contributing! This guide describes how to propose to
 4. **Validate** – Run `scripts/validate-toolkit.sh` (or the relevant automation) and capture output in your PR description.
 5. **Document** – Update README files, changelogs, and catalog metadata as needed.
    - Keep `toolkits/<slug>/README.md` current; reviewers treat it as the
-     canonical install guide.
-   - Create a documentation landing page at `docs/<slug>/index.md` (copy
-     `docs/sample-toolkit/index.md` as a template) and add it to `mkdocs.yml`.
-   - Update `catalog/toolkits.json` with `docs_url`, `categories`, and other
-     metadata so the browse experience lists your submission.
+     canonical install guide and the automation mirrors it to `docs/<slug>/index.md`.
+   - Update `catalog/toolkits.json` with `docs_url`, `bundle_url`, `categories`,
+     and other metadata so the browse experience lists your submission.
 6. **Submit** – Open a PR using the template in `.github/PULL_REQUEST_TEMPLATE.md`.
 7. **Review** – Address reviewer feedback promptly. Maintainers will verify packaging, security expectations, and documentation coverage.
 
@@ -29,8 +27,9 @@ Thanks for your interest in contributing! This guide describes how to propose to
 - [ ] Toolkit directory follows `toolkits/<slug>/` layout with `toolkit.json` and optional runtime modules.
 - [ ] Bundle builds with `scripts/package-toolkit.sh <slug>`.
 - [ ] Toolkit metadata appears in `catalog/toolkits.json` with accurate version and tags.
-- [ ] Catalog entry includes `docs_url` (e.g. `"<slug>/"`) and at least one
-      `categories` value for the browse filters.
+- [ ] Catalog entry includes `docs_url` (e.g. `"<slug>/"`), a `bundle_url`
+      under `toolkits/<slug>/bundle/`, and at least one `categories` value for
+      the browse filters.
 - [ ] Documentation under `toolkits/<slug>/docs/` covers installation, configuration, and known limitations.
 - [ ] Public docs exist at `docs/<slug>/index.md` and are linked from the
       MkDocs navigation.

--- a/catalog/toolkits.json
+++ b/catalog/toolkits.json
@@ -11,6 +11,7 @@
       "maintainers": ["toolbox-maintainers@example.com"],
       "source": "toolkits/sample-toolkit",
       "docs_url": "sample-toolkit/",
+      "bundle_url": "toolkits/sample-toolkit/bundle/",
       "categories": ["Diagnostics", "Examples"]
     }
   ]

--- a/docs/governance/contribution-process.md
+++ b/docs/governance/contribution-process.md
@@ -14,8 +14,8 @@ This repository maintains the public catalog of SRE Toolbox toolkits. The proces
 2. **Implementation** – Contributor develops the toolkit in a fork, following `docs/toolkit-authoring/` guidance and adding documentation.
 3. **Validation** – Contributor runs `scripts/validate-toolkit.sh <slug>` and shares results, along with manual test notes.
 4. **Pull request** – Contributor submits a PR using `.github/PULL_REQUEST_TEMPLATE.md`, attaches the packaged bundle, and includes the security questionnaire. The PR must also:
-   - Publish a documentation page at `docs/<slug>/index.md` (copy the sample toolkit page as a starting point) and add it to `mkdocs.yml`.
-   - Update `catalog/toolkits.json` with accurate metadata, including `docs_url` and relevant `categories` for the browse experience.
+   - Ensure `toolkits/<slug>/README.md` is comprehensive; the automation mirrors it to `docs/<slug>/index.md`, which must be linked from `mkdocs.yml`.
+   - Update `catalog/toolkits.json` with accurate metadata, including `docs_url`, `bundle_url` (pointing to `toolkits/<slug>/bundle/`), and relevant `categories` for the browse experience.
 5. **Review** – Maintainers perform code review, run validation scripts, and request adjustments as needed. Security reviewer signs off when required.
 6. **Catalog update** – Once approved, maintainers merge the PR, regenerate catalog metadata if necessary, verify the browse interface lists the toolkit, and publish the bundle to GitHub Releases.
 7. **Announcement** – Maintainers update `docs/changelog.md` and share availability through community channels.
@@ -23,9 +23,9 @@ This repository maintains the public catalog of SRE Toolbox toolkits. The proces
 ## Documentation expectations
 
 - Treat `toolkits/<slug>/README.md` as the authoritative installation and operations guide. It should mirror what operators see after downloading the bundle.
-- Mirror the README highlights in a public documentation page at `docs/<slug>/index.md`. This page powers the catalog browser and should summarize features, installation steps, and maintenance notes.
+- Mirror the README highlights in a public documentation page at `docs/<slug>/index.md`. The sync automation keeps this page aligned with the README and powers the catalog browser.
 - Reference deeper runbooks or FAQs from `toolkits/<slug>/docs/` within the public page so users can drill into details without leaving the site.
-- Keep `catalog/toolkits.json` in sync with each release. Update `version`, `description`, `docs_url` (typically `"<slug>/"`), `tags`, and `categories` so the browse experience remains accurate.
+- Keep `catalog/toolkits.json` in sync with each release. Update `version`, `description`, `docs_url` (typically `"<slug>/"`), `bundle_url` (`toolkits/<slug>/bundle/`), `tags`, and `categories` so the browse experience remains accurate.
 
 ## Service-level expectations
 

--- a/docs/sample-toolkit/index.md
+++ b/docs/sample-toolkit/index.md
@@ -2,28 +2,27 @@
 title: Sample Diagnostics Toolkit
 ---
 
+<!-- This file is auto-generated from toolkits/sample-toolkit/README.md. -->
+
 # Sample Diagnostics Toolkit
 
-The Sample Diagnostics Toolkit acts as a reference implementation for community contributors. It demonstrates the expected bundle layout and runtime entry points used by SRE Toolbox installations.
+This toolkit demonstrates repository conventions for backend, worker, and frontend integration.
 
-## Runtime components
+## Features
 
-- **Backend** – Exposes `/toolkits/sample/health` for smoke testing.
-- **Worker** – Registers the `sample-toolkit.run_diagnostics` Celery task, which emits a static success payload.
-- **Frontend** – Renders a minimal panel that confirms the bundle mounted correctly.
+- FastAPI route at `/toolkits/sample/health` for installation smoke tests.
+- Celery task `sample-toolkit.run_diagnostics` returning a static diagnostic payload.
+- Minimal React panel confirming frontend mounting.
 
-## Installation and packaging
+## Installation
 
-1. Clone the repository and ensure Python 3.11+ is available.
-2. Package the toolkit:
+1. Package the toolkit:
    ```bash
    scripts/package-toolkit.sh sample-toolkit
    ```
-3. Upload the generated zip (`dist/sample-toolkit-<date>.zip`) through the Toolbox Admin → Toolkits UI.
-4. Verify the `/toolkits/sample/health` endpoint returns HTTP 200 with status `ok`.
+2. Upload the generated zip (`dist/sample-toolkit-<date>.zip`) through the Toolbox Admin → Toolkits UI.
+3. Verify the `/toolkits/sample/health` endpoint returns a 200 status.
 
-The toolkit manifest is available at [`toolkits/sample-toolkit/toolkit.json`]({{ repo_url }}/blob/main/toolkits/sample-toolkit/toolkit.json).
+## Configuration
 
-## Maintenance
-
-The toolkit is maintained by the SRE Toolbox core team and should remain stable. Use it as a scaffold when authoring new toolkits and update documentation to reflect best practices.
+No runtime configuration is required. Use this toolkit as a scaffold when authoring your own bundles.

--- a/docs/toolkit-authoring/packaging.md
+++ b/docs/toolkit-authoring/packaging.md
@@ -5,7 +5,7 @@ Once your toolkit implementation is ready, follow the steps below to bundle it f
 ## 1. Update metadata
 
 - Ensure `toolkits/<slug>/toolkit.json` is complete and versioned.
-- Add or update the corresponding entry in `catalog/toolkits.json` (keep entries sorted alphabetically by slug). Include `docs_url` (for example, `"<slug>/"`) and at least one `categories` value so the browse experience can surface your toolkit.
+- Add or update the corresponding entry in `catalog/toolkits.json` (keep entries sorted alphabetically by slug). Include `docs_url` (for example, `"<slug>/"`), a `bundle_url` pointing to `toolkits/<slug>/bundle/`, and at least one `categories` value so the browse experience can surface your toolkit.
 - Provide changelog context in `docs/changelog.md` when releasing updates.
 
 ## 2. Validate locally
@@ -30,8 +30,7 @@ Attach the resulting zip to your pull request. Reviewers will attempt installati
 
 ## 4. Document the release
 
-- Update `toolkits/<slug>/README.md` with installation and configuration notes.
-- Publish a documentation landing page under `docs/<slug>/index.md` that summarizes key capabilities, installation steps, and maintenance expectations. The [sample toolkit page](../sample-toolkit/index.md) provides a copy-friendly template.
+- Keep `toolkits/<slug>/README.md` current; the sync script mirrors it to `docs/<slug>/index.md` so the documentation site stays fresh.
 - Provide operator-focused documentation under `toolkits/<slug>/docs/` (runbook, troubleshooting, FAQ).
 - Complete the security review questionnaire (`docs/governance/security-review.md`) and attach it to the PR.
 

--- a/docs/toolkits/sample-toolkit/bundle/index.html
+++ b/docs/toolkits/sample-toolkit/bundle/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=../bundle.zip">
+    <title>Downloading sample-toolkit bundle</title>
+  </head>
+  <body>
+    <p>If you are not redirected automatically, <a href="../bundle.zip">download the bundle</a>.</p>
+  </body>
+</html>

--- a/scripts/build_toolkit_bundle.py
+++ b/scripts/build_toolkit_bundle.py
@@ -8,7 +8,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
-def bundle_toolkit(slug: str, output: Path) -> None:
+def bundle_toolkit(slug: str, output: Path, *, quiet: bool = False) -> None:
     toolkit_dir = REPO_ROOT / "toolkits" / slug
     if not toolkit_dir.exists():
         raise FileNotFoundError(f"toolkits/{slug} does not exist")
@@ -19,13 +19,13 @@ def bundle_toolkit(slug: str, output: Path) -> None:
 
     # Preserve relative paths inside the archive.
     with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as bundle:
-        for path in toolkit_dir.rglob("*"):
+        for path in sorted(toolkit_dir.rglob("*")):
             if path.is_dir():
                 continue
             relative = path.relative_to(toolkit_dir)
             bundle.write(path, arcname=os.path.join(slug, relative.as_posix()))
-
-    print(f"Wrote {output.name} ({output.stat().st_size} bytes)")
+    if not quiet:
+        print(f"Wrote {output.name} ({output.stat().st_size} bytes)")
 
 
 def main(argv: list[str]) -> int:

--- a/scripts/package-toolkit.sh
+++ b/scripts/package-toolkit.sh
@@ -19,6 +19,11 @@ fi
 mkdir -p "$output_dir"
 package_name="${slug}-$(date +%Y%m%d).zip"
 
+# Regenerate generated documentation and bundle assets before validation so
+# validate_catalog.py sees the latest bundle artifacts even if they are
+# gitignored.
+python "$repo_root/scripts/sync_toolkit_assets.py" --slug "$slug"
+
 python "$repo_root/scripts/validate_catalog.py" --toolkit "$slug"
 python "$repo_root/scripts/build_toolkit_bundle.py" --slug "$slug" --output "$output_dir/$package_name"
 

--- a/scripts/sync_toolkit_assets.py
+++ b/scripts/sync_toolkit_assets.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Synchronize generated documentation and bundles for each toolkit.
+
+This helper keeps the MkDocs documentation tree and downloadable bundles in
+sync with the source toolkits stored under ``toolkits/``.  Running the script
+ensures ``docs/<slug>/index.md`` mirrors ``toolkits/<slug>/README.md`` and that
+``docs/toolkits/<slug>/bundle.zip`` is freshly packaged.
+
+The script is idempotent: files are only rewritten when their content changes
+to avoid unnecessary churn in the git working tree.
+"""
+from __future__ import annotations
+
+import argparse
+import filecmp
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCS_ROOT = REPO_ROOT / "docs"
+TOOLKITS_ROOT = REPO_ROOT / "toolkits"
+
+
+def _import_bundle_toolkit():  # pragma: no cover - thin wrapper for clarity
+    """Return the ``bundle_toolkit`` helper without creating a package."""
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    try:
+        from build_toolkit_bundle import bundle_toolkit  # type: ignore
+    finally:
+        sys.path.pop(0)
+    return bundle_toolkit
+
+
+bundle_toolkit = _import_bundle_toolkit()
+
+
+def _first_heading(markdown: str) -> str | None:
+    for line in markdown.splitlines():
+        line = line.strip()
+        if line.startswith("# "):
+            return line[2:].strip()
+    return None
+
+
+def _write_text_if_changed(path: Path, content: str) -> bool:
+    if path.exists() and path.read_text(encoding="utf-8") == content:
+        return False
+    path.write_text(content, encoding="utf-8")
+    return True
+
+
+def _write_binary_if_changed(source: Path, target: Path) -> bool:
+    if target.exists() and filecmp.cmp(source, target, shallow=False):
+        return False
+    target.write_bytes(source.read_bytes())
+    return True
+
+
+def _render_redirect_html(slug: str) -> str:
+    download_href = "../bundle.zip"
+    return textwrap.dedent(
+        f"""\
+        <!doctype html>
+        <html lang="en">
+          <head>
+            <meta charset="utf-8">
+            <meta http-equiv="refresh" content="0; url={download_href}">
+            <title>Downloading {slug} bundle</title>
+          </head>
+          <body>
+            <p>If you are not redirected automatically, <a href="{download_href}">download the bundle</a>.</p>
+          </body>
+        </html>
+        """
+    )
+
+
+def sync_toolkit(slug: str) -> None:
+    toolkit_dir = TOOLKITS_ROOT / slug
+    if not toolkit_dir.exists():
+        raise SystemExit(f"toolkits/{slug} does not exist")
+
+    readme_path = toolkit_dir / "README.md"
+    if readme_path.exists():
+        markdown = readme_path.read_text(encoding="utf-8").strip()
+        title = _first_heading(markdown) or slug.replace("-", " ").title()
+        relative_readme = readme_path.relative_to(REPO_ROOT)
+        header_lines = [
+            "---",
+            f"title: {title}",
+            "---",
+            "",
+            f"<!-- This file is auto-generated from {relative_readme.as_posix()}. -->",
+            "",
+        ]
+        document = "\n".join(header_lines + [markdown])
+        if not document.endswith("\n"):
+            document += "\n"
+
+        docs_dir = DOCS_ROOT / slug
+        docs_dir.mkdir(parents=True, exist_ok=True)
+        _write_text_if_changed(docs_dir / "index.md", document)
+
+    bundles_root = DOCS_ROOT / "toolkits" / slug
+    bundles_root.mkdir(parents=True, exist_ok=True)
+    bundle_zip = bundles_root / "bundle.zip"
+
+    with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+    try:
+        bundle_toolkit(slug, tmp_path, quiet=True)
+        _write_binary_if_changed(tmp_path, bundle_zip)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+    redirect_dir = bundles_root / "bundle"
+    redirect_dir.mkdir(parents=True, exist_ok=True)
+    redirect_path = redirect_dir / "index.html"
+    _write_text_if_changed(redirect_path, _render_redirect_html(slug))
+
+
+def discover_toolkits() -> list[str]:
+    return sorted(path.name for path in TOOLKITS_ROOT.iterdir() if path.is_dir())
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Sync generated docs and bundles for toolkits")
+    parser.add_argument("--slug", help="Only sync a specific toolkit slug")
+    args = parser.parse_args(argv)
+
+    slugs = [args.slug] if args.slug else discover_toolkits()
+    for slug in slugs:
+        sync_toolkit(slug)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -5,6 +5,9 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 
 cd "$repo_root"
 
+# Ensure generated documentation and bundles are current.
+python scripts/sync_toolkit_assets.py
+
 # Ensure toolkit metadata stays in sync with directory contents.
 python scripts/validate_catalog.py
 

--- a/scripts/validate-toolkit.sh
+++ b/scripts/validate-toolkit.sh
@@ -8,4 +8,5 @@ fi
 
 slug="$1"
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+python "$repo_root/scripts/sync_toolkit_assets.py" --slug "$slug"
 python "$repo_root/scripts/validate_catalog.py" --toolkit "$slug" --strict


### PR DESCRIPTION
## Summary
- ignore generated toolkit bundle archives so they are produced at build time instead of committed
- ensure per-toolkit validation regenerates bundle assets before running catalog checks

## Testing
- scripts/validate-repo.sh
- mkdocs build --strict --clean --site-dir site

------
https://chatgpt.com/codex/tasks/task_b_68d0c8fc04448328a6f65da6471de017