### PR TITLE
Generate toolkit bundles on demand

### DIFF
--- a/docs/toolkits/sample-toolkit/bundle/index.html
+++ b/docs/toolkits/sample-toolkit/bundle/index.html
@@ -2,10 +2,19 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="refresh" content="0; url=../bundle.zip">
-    <title>Downloading sample-toolkit bundle</title>
+    <title>Download sample-toolkit bundle</title>
   </head>
   <body>
-    <p>If you are not redirected automatically, <a href="../bundle.zip">download the bundle</a>.</p>
+    <h1>Download sample-toolkit bundle</h1>
+    <p>
+      Bundles are generated on demand when requested from a running
+      Toolbox instance. Access this bundle via
+      <code>/toolkits/sample-toolkit/bundle</code> on your deployment to
+      receive the latest archive.
+    </p>
+    <p>
+      This placeholder page remains in the documentation so historical
+      links stay functional.
+    </p>
   </body>
 </html>

--- a/scripts/build_toolkit_bundle.py
+++ b/scripts/build_toolkit_bundle.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import io
 import json
 import os
 import zipfile
@@ -8,7 +9,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
-def bundle_toolkit(slug: str, output: Path, *, quiet: bool = False) -> None:
+def _resolve_toolkit_paths(slug: str) -> Path:
     toolkit_dir = REPO_ROOT / "toolkits" / slug
     if not toolkit_dir.exists():
         raise FileNotFoundError(f"toolkits/{slug} does not exist")
@@ -17,13 +18,32 @@ def bundle_toolkit(slug: str, output: Path, *, quiet: bool = False) -> None:
     if not manifest_path.exists():
         raise FileNotFoundError(f"toolkits/{slug}/toolkit.json is required")
 
-    # Preserve relative paths inside the archive.
-    with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as bundle:
-        for path in sorted(toolkit_dir.rglob("*")):
-            if path.is_dir():
-                continue
-            relative = path.relative_to(toolkit_dir)
-            bundle.write(path, arcname=os.path.join(slug, relative.as_posix()))
+    return toolkit_dir
+
+
+def _iter_toolkit_files(toolkit_dir: Path, *, slug: str):
+    for path in sorted(toolkit_dir.rglob("*")):
+        if path.is_dir():
+            continue
+        relative = path.relative_to(toolkit_dir)
+        arcname = os.path.join(slug, relative.as_posix())
+        yield path, arcname
+
+
+def build_bundle_bytes(slug: str) -> bytes:
+    """Return a zip archive for *slug* as an in-memory byte string."""
+
+    toolkit_dir = _resolve_toolkit_paths(slug)
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", compression=zipfile.ZIP_DEFLATED) as bundle:
+        for source, arcname in _iter_toolkit_files(toolkit_dir, slug=slug):
+            bundle.write(source, arcname=arcname)
+    return buffer.getvalue()
+
+
+def bundle_toolkit(slug: str, output: Path, *, quiet: bool = False) -> None:
+    data = build_bundle_bytes(slug)
+    output.write_bytes(data)
     if not quiet:
         print(f"Wrote {output.name} ({output.stat().st_size} bytes)")
 

--- a/scripts/package-toolkit.sh
+++ b/scripts/package-toolkit.sh
@@ -19,9 +19,8 @@ fi
 mkdir -p "$output_dir"
 package_name="${slug}-$(date +%Y%m%d).zip"
 
-# Regenerate generated documentation and bundle assets before validation so
-# validate_catalog.py sees the latest bundle artifacts even if they are
-# gitignored.
+# Regenerate generated documentation and bundle placeholders before validation
+# so validate_catalog.py sees the latest assets even if they are gitignored.
 python "$repo_root/scripts/sync_toolkit_assets.py" --slug "$slug"
 
 python "$repo_root/scripts/validate_catalog.py" --toolkit "$slug"

--- a/scripts/tests/test_bundle_generation.py
+++ b/scripts/tests/test_bundle_generation.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import io
+import tempfile
+import zipfile
+import unittest
+from pathlib import Path
+
+from scripts.build_toolkit_bundle import build_bundle_bytes, bundle_toolkit
+from toolkit_bundle_service import application
+
+
+class BuildBundleBytesTests(unittest.TestCase):
+    def test_bundle_includes_manifest(self) -> None:
+        data = build_bundle_bytes("sample-toolkit")
+        self.assertGreater(len(data), 0)
+
+        with zipfile.ZipFile(io.BytesIO(data)) as archive:
+            names = archive.namelist()
+        self.assertIn("sample-toolkit/toolkit.json", names)
+
+    def test_bundle_toolkit_writes_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            target = Path(tmp_dir) / "bundle.zip"
+            bundle_toolkit("sample-toolkit", target, quiet=True)
+            self.assertTrue(target.exists())
+            self.assertGreater(target.stat().st_size, 0)
+
+
+class BundleServiceTests(unittest.TestCase):
+    def _invoke(self, path: str, method: str = "GET"):
+        captured: dict[str, object] = {}
+
+        def start_response(status: str, headers: list[tuple[str, str]]) -> None:
+            captured["status"] = status
+            captured["headers"] = dict(headers)
+
+        environ = {"PATH_INFO": path, "REQUEST_METHOD": method}
+        body = b"".join(application(environ, start_response))
+        status_line = captured.get("status", "500 Internal Server Error")
+        headers = captured.get("headers", {})
+        return status_line, headers, body
+
+    def test_download_returns_zip_archive(self) -> None:
+        status, headers, body = self._invoke("/toolkits/sample-toolkit/bundle")
+        self.assertTrue(status.startswith("200"))
+        self.assertEqual(headers.get("Content-Type"), "application/zip")
+        self.assertIn(
+            "attachment; filename=\"sample-toolkit.zip\"",
+            headers.get("Content-Disposition", ""),
+        )
+
+        with zipfile.ZipFile(io.BytesIO(body)) as archive:
+            self.assertIn("sample-toolkit/toolkit.json", archive.namelist())
+
+    def test_head_request_returns_metadata_only(self) -> None:
+        status, headers, body = self._invoke("/toolkits/sample-toolkit/bundle", method="HEAD")
+        self.assertTrue(status.startswith("200"))
+        self.assertEqual(body, b"")
+        self.assertEqual(headers.get("Content-Type"), "application/zip")
+
+    def test_download_missing_toolkit(self) -> None:
+        status, headers, body = self._invoke("/toolkits/does-not-exist/bundle")
+        self.assertTrue(status.startswith("404"))
+        self.assertEqual(headers.get("Content-Type"), "text/plain; charset=utf-8")
+        self.assertEqual(body, b"Toolkit not found")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-repo.sh
+++ b/scripts/validate-repo.sh
@@ -5,7 +5,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 
 cd "$repo_root"
 
-# Ensure generated documentation and bundles are current.
+# Ensure generated documentation and bundle placeholders are current.
 python scripts/sync_toolkit_assets.py
 
 # Ensure toolkit metadata stays in sync with directory contents.

--- a/scripts/validate_catalog.py
+++ b/scripts/validate_catalog.py
@@ -63,13 +63,12 @@ def validate_entry(slug: str, entry: dict, *, strict: bool) -> list[str]:
     if not doc_page.exists():
         issues.append(f"Documentation page missing: docs/{slug}/index.md")
 
-    bundle_asset = REPO_ROOT / "docs" / "toolkits" / slug / "bundle.zip"
-    if not bundle_asset.exists():
-        issues.append(f"Bundle archive missing: docs/toolkits/{slug}/bundle.zip")
-    redirect_asset = REPO_ROOT / "docs" / "toolkits" / slug / "bundle" / "index.html"
-    if not redirect_asset.exists():
+    placeholder_asset = (
+        REPO_ROOT / "docs" / "toolkits" / slug / "bundle" / "index.html"
+    )
+    if not placeholder_asset.exists():
         issues.append(
-            f"Bundle redirect missing: docs/toolkits/{slug}/bundle/index.html"
+            f"Bundle placeholder missing: docs/toolkits/{slug}/bundle/index.html"
         )
     return issues
 

--- a/toolkit_bundle_service.py
+++ b/toolkit_bundle_service.py
@@ -1,0 +1,78 @@
+"""WSGI application serving toolkit bundles on demand."""
+from __future__ import annotations
+
+from typing import Callable, Iterable
+
+from scripts.build_toolkit_bundle import build_bundle_bytes
+
+StartResponse = Callable[[str, list[tuple[str, str]]], None]
+Environ = dict[str, str]
+
+
+def _parse_slug(path: str) -> str | None:
+    if not path.startswith("/toolkits/"):
+        return None
+    remainder = path[len("/toolkits/") :]
+    parts = [segment for segment in remainder.split("/") if segment]
+    if len(parts) != 2:
+        return None
+    slug, endpoint = parts
+    if endpoint != "bundle" or not slug:
+        return None
+    return slug
+
+
+def _not_found(start_response: StartResponse) -> Iterable[bytes]:
+    body = b"Toolkit not found"
+    start_response(
+        "404 Not Found",
+        [("Content-Type", "text/plain; charset=utf-8"), ("Content-Length", str(len(body)))],
+    )
+    return [body]
+
+
+def _method_not_allowed(start_response: StartResponse) -> Iterable[bytes]:
+    body = b"Method not allowed"
+    start_response(
+        "405 Method Not Allowed",
+        [
+            ("Content-Type", "text/plain; charset=utf-8"),
+            ("Content-Length", str(len(body))),
+            ("Allow", "GET, HEAD"),
+        ],
+    )
+    return [body]
+
+
+def application(environ: Environ, start_response: StartResponse) -> Iterable[bytes]:
+    """WSGI entrypoint returning toolkit bundles as zip archives."""
+
+    path = environ.get("PATH_INFO", "")
+    method = environ.get("REQUEST_METHOD", "GET").upper()
+
+    if method not in {"GET", "HEAD"}:
+        return _method_not_allowed(start_response)
+
+    slug = _parse_slug(path)
+    if not slug:
+        return _not_found(start_response)
+
+    try:
+        bundle = build_bundle_bytes(slug)
+    except FileNotFoundError:
+        return _not_found(start_response)
+
+    headers = [
+        ("Content-Type", "application/zip"),
+        ("Content-Disposition", f'attachment; filename="{slug}.zip"'),
+        ("Cache-Control", "no-store"),
+        ("Content-Length", str(len(bundle))),
+    ]
+    start_response("200 OK", headers)
+
+    if method == "HEAD":
+        return [b""]
+    return [bundle]
+
+
+__all__ = ["application"]


### PR DESCRIPTION
## Summary
- add a lightweight WSGI endpoint that creates toolkit bundles when `/toolkits/{slug}/bundle` is requested
- refactor bundle packaging helpers and documentation sync to rely on in-memory archives and placeholder download pages instead of stored zip files
- add unit tests covering bundle byte generation and the new endpoint behaviour

## Testing
- python -m unittest discover -s scripts/tests
- scripts/validate-repo.sh
- mkdocs build --strict --clean --site-dir site

------
https://chatgpt.com/codex/tasks/task_b_68d0d51d787c8328ab1c6f18c88a9cde