### PR TITLE
Serve catalog manifest alongside bundle endpoint

### DIFF
--- a/scripts/tests/test_bundle_generation.py
+++ b/scripts/tests/test_bundle_generation.py
@@ -41,6 +41,21 @@ class BundleServiceTests(unittest.TestCase):
         headers = captured.get("headers", {})
         return status_line, headers, body
 
+    def test_catalog_manifest_served_from_disk(self) -> None:
+        status, headers, body = self._invoke("/catalog/toolkits.json")
+        self.assertTrue(status.startswith("200"))
+        self.assertEqual(headers.get("Content-Type"), "application/json; charset=utf-8")
+
+        repo_root = Path(__file__).resolve().parents[2]
+        manifest_bytes = (repo_root / "catalog" / "toolkits.json").read_bytes()
+        self.assertEqual(body, manifest_bytes)
+
+    def test_catalog_manifest_head_request(self) -> None:
+        status, headers, body = self._invoke("/catalog/toolkits.json", method="HEAD")
+        self.assertTrue(status.startswith("200"))
+        self.assertEqual(body, b"")
+        self.assertEqual(headers.get("Content-Type"), "application/json; charset=utf-8")
+
     def test_download_returns_zip_archive(self) -> None:
         status, headers, body = self._invoke("/toolkits/sample-toolkit/bundle")
         self.assertTrue(status.startswith("200"))


### PR DESCRIPTION
## Summary
- serve `/catalog/toolkits.json` through the WSGI app while keeping bundle downloads unchanged
- add regression tests covering GET and HEAD requests for the catalog manifest

## Testing
- scripts/validate-repo.sh
- mkdocs build --strict --clean --site-dir site
- python -m unittest scripts.tests.test_bundle_generation

------
https://chatgpt.com/codex/tasks/task_b_68d0e973d3ac8328b63d6f95f09409bc