### PR TITLE
Fix toolkit browser container ID

### DIFF
--- a/docs/toolkit-browser.md
+++ b/docs/toolkit-browser.md
@@ -12,7 +12,7 @@ immediately.
   </div>
 </noscript>
 
-<div id="toolkit-browser" class="toolkit-browser" data-raw-catalog-url="{{ raw_catalog_url }}">
+<div id="toolkit-browser-app" class="toolkit-browser" data-raw-catalog-url="{{ raw_catalog_url }}">
   <div class="toolkit-browser__loading" role="status">Loading catalog…</div>
 </div>
 
@@ -207,7 +207,7 @@ immediately.
 
 <script>
   (function () {
-    const root = document.getElementById("toolkit-browser");
+    const root = document.getElementById("toolkit-browser-app");
     if (!root) {
       return;
     }


### PR DESCRIPTION
## Summary
- ensure the toolkit browser script targets a unique container id
- fix the layout regression that caused oversized controls on the browse page

## Testing
- `PYTHONPATH=$PWD scripts/validate-repo.sh`
- `PYTHONPATH=$PWD mkdocs build --strict --clean --site-dir site`


------
https://chatgpt.com/codex/tasks/task_b_68d2273bfc148328be7aa9ad31c29cc6