### PR TITLE
Fix base paths for underscore-slug toolkits

### DIFF
--- a/docs/catalog/toolkits.json
+++ b/docs/catalog/toolkits.json
@@ -1,7 +1,71 @@
 {
   "version": 1,
-  "generated_at": "2025-09-22T09:15:18Z",
+  "generated_at": "2025-09-23T05:31:37Z",
   "toolkits": [
+    {
+      "slug": "api_checker",
+      "name": "API Checker",
+      "version": "0.1.0",
+      "description": "Craft HTTP requests, explore APIs, and inspect responses with ease.",
+      "tags": [
+        "http",
+        "api",
+        "requests",
+        "debugging"
+      ],
+      "maintainers": [
+        "sxmxc"
+      ],
+      "source": "toolkits/api_checker",
+      "docs_url": "toolkits/api_checker/",
+      "bundle_url": "toolkits/api_checker/bundle.zip",
+      "categories": [
+        "Diagnostics"
+      ]
+    },
+    {
+      "slug": "connectivity",
+      "name": "Bulk Connectivity Checker",
+      "version": "0.1.0",
+      "description": "Run large-scale reachability probes, track failures, and automate remediation.",
+      "tags": [
+        "networking",
+        "reachability",
+        "tcp",
+        "automation"
+      ],
+      "maintainers": [
+        "sxmxc"
+      ],
+      "source": "toolkits/connectivity",
+      "docs_url": "toolkits/connectivity/",
+      "bundle_url": "toolkits/connectivity/bundle.zip",
+      "categories": [
+        "Networking"
+      ]
+    },
+    {
+      "slug": "latency_sleuth",
+      "name": "Latency Sleuth",
+      "version": "1.0.0",
+      "description": "Model web latency probes, tune SLAs, and visualise performance drift with synthetic checks.",
+      "tags": [
+        "synthetic",
+        "latency",
+        "sla",
+        "http",
+        "probes"
+      ],
+      "maintainers": [
+        "sxmxc"
+      ],
+      "source": "toolkits/latency_sleuth",
+      "docs_url": "toolkits/latency_sleuth/",
+      "bundle_url": "toolkits/latency_sleuth/bundle.zip",
+      "categories": [
+        "Monitoring"
+      ]
+    },
     {
       "slug": "regex",
       "name": "Regex Toolkit",
@@ -40,6 +104,48 @@
       "categories": [
         "Diagnostics",
         "Examples"
+      ]
+    },
+    {
+      "slug": "toolbox_health",
+      "name": "Toolbox Health",
+      "version": "0.1.0",
+      "description": "Monitor the Toolbox frontend, backend, and worker services.",
+      "tags": [
+        "toolbox",
+        "health",
+        "status",
+        "telemetry"
+      ],
+      "maintainers": [
+        "sxmxc"
+      ],
+      "source": "toolkits/toolbox_health",
+      "docs_url": "toolkits/toolbox_health/",
+      "bundle_url": "toolkits/toolbox_health/bundle.zip",
+      "categories": [
+        "Monitoring"
+      ]
+    },
+    {
+      "slug": "zabbix",
+      "name": "Zabbix Toolkit",
+      "version": "0.1.0",
+      "description": "Manage Zabbix API endpoints and automation workflows.",
+      "tags": [
+        "zabbix",
+        "automation",
+        "api",
+        "inventory"
+      ],
+      "maintainers": [
+        "sxmxc"
+      ],
+      "source": "toolkits/zabbix",
+      "docs_url": "toolkits/zabbix/",
+      "bundle_url": "toolkits/zabbix/bundle.zip",
+      "categories": [
+        "Integrations"
       ]
     }
   ]

--- a/docs/toolkits/api_checker/index.md
+++ b/docs/toolkits/api_checker/index.md
@@ -8,7 +8,7 @@ title: API Checker toolkit
 
 API Checker lets operators craft HTTP requests, attach auth headers, and inspect
 responses without leaving Toolbox. The bundle ships FastAPI routes under
-`/toolkits/api-checker`, a Celery-friendly job helper, and a React UI panel for
+`/toolkits/api_checker`, a Celery-friendly job helper, and a React UI panel for
 interactive exploration.
 
 ## Validate before publishing
@@ -31,7 +31,7 @@ interactive exploration.
   payload are included when applicable.
 - Jobs can be enqueued through `toolkit_runtime.enqueue_job` for long-running
   probes; the UI streams progress from the backend utilities in `backend/app.py`.
-- The React panel renders under `/toolkits/api-checker` inside the Toolbox shell
+- The React panel renders under `/toolkits/api_checker` inside the Toolbox shell
   once the bundle is installed.
 
 ## Operator checklist

--- a/docs/toolkits/latency_sleuth/index.md
+++ b/docs/toolkits/latency_sleuth/index.md
@@ -33,7 +33,7 @@ scheduled executions, and a React dashboard that highlights trends.
   refresh cached telemetry snapshots.
 - Dashboard context from `backend/dashboard.py` powers the React UI so operators
   can visualise breach streaks and SLA adherence.
-- Bundled assets mount under `/toolkits/latency-sleuth` within the Toolbox App
+- Bundled assets mount under `/toolkits/latency_sleuth` within the Toolbox App
   Shell once the toolkit installs successfully.
 
 ## Operator checklist

--- a/docs/toolkits/toolbox_health/index.md
+++ b/docs/toolkits/toolbox_health/index.md
@@ -27,20 +27,20 @@ component status.
 
 ## Runtime expectations
 
-- FastAPI routes under `/toolkits/toolbox-health/health` serve component and
+- FastAPI routes under `/toolkits/toolbox_health/health` serve component and
   summary payloads sourced from `backend/health.py`.
 - Celery registration in `worker/tasks.py` schedules periodic refresh jobs to
   keep cached snapshots warm.
 - Dashboard context defined in `backend/dashboard.py` powers the React widgets
   bundled in `frontend/`.
-- Installation adds a dashboard card linking to `/toolkits/toolbox-health` in
+- Installation adds a dashboard card linking to `/toolkits/toolbox_health` in
   the Toolbox UI.
 
 ## Operator checklist
 
 1. Install the bundle via the admin UI or `/toolkits/install` API.
 2. Confirm the dashboard card renders and displays component status.
-3. Call `/toolkits/toolbox-health/health/summary?force_refresh=true` to validate
+3. Call `/toolkits/toolbox_health/health/summary?force_refresh=true` to validate
   backend refresh logic.
 4. Review Celery worker logs for refresh job execution and ensure metrics align
   with expectations.

--- a/toolkits/api_checker/docs/README.md
+++ b/toolkits/api_checker/docs/README.md
@@ -2,7 +2,7 @@
 
 API Checker lets operators craft HTTP requests, attach auth headers, and inspect
 responses without leaving Toolbox. The bundle ships FastAPI routes under
-`/toolkits/api-checker`, a Celery-friendly job helper, and a React UI panel for
+`/toolkits/api_checker`, a Celery-friendly job helper, and a React UI panel for
 interactive exploration.
 
 ## Validate before publishing
@@ -25,7 +25,7 @@ interactive exploration.
   payload are included when applicable.
 - Jobs can be enqueued through `toolkit_runtime.enqueue_job` for long-running
   probes; the UI streams progress from the backend utilities in `backend/app.py`.
-- The React panel renders under `/toolkits/api-checker` inside the Toolbox shell
+- The React panel renders under `/toolkits/api_checker` inside the Toolbox shell
   once the bundle is installed.
 
 ## Operator checklist

--- a/toolkits/api_checker/docs/TESTING.md
+++ b/toolkits/api_checker/docs/TESTING.md
@@ -13,7 +13,7 @@
    unzip -t /tmp/api-checker.zip
    ```
 4. Upload `/tmp/api-checker.zip` through the Toolbox admin UI.
-5. Issue a sample request via the UI or POST `/toolkits/api-checker/requests`
+5. Issue a sample request via the UI or POST `/toolkits/api_checker/requests`
    with the payload from `backend/app.py` to confirm a `200 OK` response.
 6. Inspect the worker/job logs to ensure long-running requests append progress
    entries when using queued jobs.

--- a/toolkits/api_checker/frontend/dist/index.js
+++ b/toolkits/api_checker/frontend/dist/index.js
@@ -23,7 +23,7 @@ var RAW_CONTENT_TYPES = [
   "application/x-www-form-urlencoded",
   "application/octet-stream"
 ];
-var HISTORY_STORAGE_KEY = "toolkits.api-checker.history.v1";
+var HISTORY_STORAGE_KEY = "toolkits.api_checker.history.v1";
 var MAX_HISTORY_ENTRIES = 25;
 var layoutStyles = {
   wrapper: {
@@ -316,7 +316,7 @@ function ApiCheckerApp() {
     setActiveHistoryId(historyId);
     setSending(true);
     try {
-      const result = await apiFetch("/toolkits/api-checker/requests", {
+      const result = await apiFetch("/toolkits/api_checker/requests", {
         method: "POST",
         body: JSON.stringify(payload)
       });

--- a/toolkits/api_checker/frontend/index.tsx
+++ b/toolkits/api_checker/frontend/index.tsx
@@ -87,7 +87,7 @@ const RAW_CONTENT_TYPES = [
   'application/octet-stream',
 ]
 
-const HISTORY_STORAGE_KEY = 'toolkits.api-checker.history.v1'
+const HISTORY_STORAGE_KEY = 'toolkits.api_checker.history.v1'
 const MAX_HISTORY_ENTRIES = 25
 
 const layoutStyles: Record<string, CSSProperties> = {
@@ -406,7 +406,7 @@ export default function ApiCheckerApp() {
     setActiveHistoryId(historyId)
     setSending(true)
     try {
-      const result = await apiFetch<ApiResponsePayload>('/toolkits/api-checker/requests', {
+      const result = await apiFetch<ApiResponsePayload>('/toolkits/api_checker/requests', {
         method: 'POST',
         body: JSON.stringify(payload),
       })

--- a/toolkits/api_checker/tests/test_backend.py
+++ b/toolkits/api_checker/tests/test_backend.py
@@ -52,7 +52,7 @@ class DummyAsyncClient:
 
 def test_execute_request_success(monkeypatch: pytest.MonkeyPatch) -> None:
     app = FastAPI()
-    app.include_router(router, prefix="/toolkits/api-checker")
+    app.include_router(router, prefix="/toolkits/api_checker")
 
     perf_values = chain([1.0, 1.25], repeat(1.25))
     monkeypatch.setattr(app_module.time, "perf_counter", lambda: next(perf_values))
@@ -79,7 +79,7 @@ def test_execute_request_success(monkeypatch: pytest.MonkeyPatch) -> None:
         "timeout": 15,
     }
 
-    response = client.post("/toolkits/api-checker/requests", json=payload)
+    response = client.post("/toolkits/api_checker/requests", json=payload)
     assert response.status_code == 200
 
     data = response.json()
@@ -99,7 +99,7 @@ def test_execute_request_success(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_execute_request_invalid_json_body(monkeypatch: pytest.MonkeyPatch) -> None:
     app = FastAPI()
-    app.include_router(router, prefix="/toolkits/api-checker")
+    app.include_router(router, prefix="/toolkits/api_checker")
 
     dummy_client = DummyAsyncClient({"status_code": 200, "json": {"ok": True}})
     monkeypatch.setattr(app_module, "create_async_client", lambda payload: dummy_client)
@@ -117,7 +117,7 @@ def test_execute_request_invalid_json_body(monkeypatch: pytest.MonkeyPatch) -> N
         "timeout": 10,
     }
 
-    response = client.post("/toolkits/api-checker/requests", json=payload)
+    response = client.post("/toolkits/api_checker/requests", json=payload)
     assert response.status_code == 400
     assert "Invalid JSON body" in response.json()["detail"]
     # The HTTP call should not be attempted when validation fails.
@@ -126,7 +126,7 @@ def test_execute_request_invalid_json_body(monkeypatch: pytest.MonkeyPatch) -> N
 
 def test_execute_request_applies_bearer_token(monkeypatch: pytest.MonkeyPatch) -> None:
     app = FastAPI()
-    app.include_router(router, prefix="/toolkits/api-checker")
+    app.include_router(router, prefix="/toolkits/api_checker")
 
     perf_values = chain([10.0, 10.1], repeat(10.1))
     monkeypatch.setattr(app_module.time, "perf_counter", lambda: next(perf_values))
@@ -160,7 +160,7 @@ def test_execute_request_applies_bearer_token(monkeypatch: pytest.MonkeyPatch) -
         "timeout": 5,
     }
 
-    response = client.post("/toolkits/api-checker/requests", json=payload)
+    response = client.post("/toolkits/api_checker/requests", json=payload)
     assert response.status_code == 200
 
     data = response.json()

--- a/toolkits/api_checker/toolkit.json
+++ b/toolkits/api_checker/toolkit.json
@@ -9,7 +9,7 @@
     "tags": ["http", "api", "requests", "debugging"],
     "description": "Craft HTTP requests, explore APIs, and inspect responses with ease."
   },
-  "base_path": "/toolkits/api-checker",
+  "base_path": "/toolkits/api_checker",
   "backend": {
     "module": "backend.app",
     "router_attr": "router"
@@ -23,7 +23,7 @@
       "title": "API Checker",
       "body": "Quickly compose requests, add auth headers, and validate external APIs.",
       "link_text": "Open",
-      "link_href": "/toolkits/api-checker"
+      "link_href": "/toolkits/api_checker"
     }
   ]
 }

--- a/toolkits/latency_sleuth/docs/README.md
+++ b/toolkits/latency_sleuth/docs/README.md
@@ -27,7 +27,7 @@ scheduled executions, and a React dashboard that highlights trends.
   refresh cached telemetry snapshots.
 - Dashboard context from `backend/dashboard.py` powers the React UI so operators
   can visualise breach streaks and SLA adherence.
-- Bundled assets mount under `/toolkits/latency-sleuth` within the Toolbox App
+- Bundled assets mount under `/toolkits/latency_sleuth` within the Toolbox App
   Shell once the toolkit installs successfully.
 
 ## Operator checklist

--- a/toolkits/latency_sleuth/frontend/components/JobLogViewer.tsx
+++ b/toolkits/latency_sleuth/frontend/components/JobLogViewer.tsx
@@ -96,7 +96,7 @@ export default function JobLogViewer() {
     if (!currentTemplate) return
     try {
       const response = await apiFetch<ProbeExecutionSummary>(
-        `/toolkits/latency-sleuth/probe-templates/${currentTemplate.id}/actions/preview`,
+        `/toolkits/latency_sleuth/probe-templates/${currentTemplate.id}/actions/preview`,
         { method: 'POST', json: { sample_size: 3 } },
       )
       setPreview(response)
@@ -112,7 +112,7 @@ export default function JobLogViewer() {
     setJobId(null)
     try {
       const response = await apiFetch<{ job: { id: string } }>(
-        `/toolkits/latency-sleuth/probe-templates/${currentTemplate.id}/actions/run`,
+        `/toolkits/latency_sleuth/probe-templates/${currentTemplate.id}/actions/run`,
         { method: 'POST', json: { sample_size: 3 } },
       )
       setJobId(response.job.id)

--- a/toolkits/latency_sleuth/frontend/components/LatencyHeatmap.tsx
+++ b/toolkits/latency_sleuth/frontend/components/LatencyHeatmap.tsx
@@ -39,7 +39,7 @@ export default function LatencyHeatmapView() {
       setError(null)
       try {
         const response = await apiFetch<LatencyHeatmap>(
-          `/toolkits/latency-sleuth/probe-templates/${currentTemplate.id}/heatmap`,
+          `/toolkits/latency_sleuth/probe-templates/${currentTemplate.id}/heatmap`,
           { method: 'GET' },
         )
         if (!cancelled) {

--- a/toolkits/latency_sleuth/frontend/dist/index.js
+++ b/toolkits/latency_sleuth/frontend/dist/index.js
@@ -44,7 +44,7 @@ function useProbeTemplates() {
     setError(null);
     try {
       const response = await apiFetch(
-        "/toolkits/latency-sleuth/probe-templates"
+        "/toolkits/latency_sleuth/probe-templates"
       );
       if (!activeRef.current) return;
       response.sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
@@ -64,7 +64,7 @@ function useProbeTemplates() {
   const createTemplate = useCallback(
     async (payload) => {
       const created = await apiFetch(
-        "/toolkits/latency-sleuth/probe-templates",
+        "/toolkits/latency_sleuth/probe-templates",
         { method: "POST", json: payload }
       );
       if (activeRef.current) {
@@ -77,7 +77,7 @@ function useProbeTemplates() {
   const updateTemplate = useCallback(
     async (templateId, payload) => {
       const updated = await apiFetch(
-        `/toolkits/latency-sleuth/probe-templates/${templateId}`,
+        `/toolkits/latency_sleuth/probe-templates/${templateId}`,
         { method: "PUT", json: payload }
       );
       if (activeRef.current) {
@@ -88,7 +88,7 @@ function useProbeTemplates() {
     []
   );
   const removeTemplate = useCallback(async (templateId) => {
-    await apiFetch(`/toolkits/latency-sleuth/probe-templates/${templateId}`, { method: "DELETE" });
+    await apiFetch(`/toolkits/latency_sleuth/probe-templates/${templateId}`, { method: "DELETE" });
     if (activeRef.current) {
       setTemplates((prev) => prev.filter((item) => item.id !== templateId));
     }
@@ -535,7 +535,7 @@ function useJobStream(jobId, pollInterval = 2e3) {
       setLoading(true);
       try {
         const response = await apiFetch(
-          `/toolkits/latency-sleuth/jobs/${currentJobId}`
+          `/toolkits/latency_sleuth/jobs/${currentJobId}`
         );
         if (!activeRef.current) return response;
         setJob(response);
@@ -611,7 +611,7 @@ function useToolkitJobs(templateId, pollInterval = 1e4) {
     setLoading(true);
     try {
       const response = await apiFetch(
-        `/toolkits/latency-sleuth/jobs?template_id=${encodeURIComponent(templateId)}`
+        `/toolkits/latency_sleuth/jobs?template_id=${encodeURIComponent(templateId)}`
       );
       if (!activeRef.current) return response;
       setJobs(response);
@@ -800,7 +800,7 @@ function JobLogViewer() {
     if (!currentTemplate) return;
     try {
       const response = await apiFetch(
-        `/toolkits/latency-sleuth/probe-templates/${currentTemplate.id}/actions/preview`,
+        `/toolkits/latency_sleuth/probe-templates/${currentTemplate.id}/actions/preview`,
         { method: "POST", json: { sample_size: 3 } }
       );
       setPreview(response);
@@ -815,7 +815,7 @@ function JobLogViewer() {
     setJobId(null);
     try {
       const response = await apiFetch(
-        `/toolkits/latency-sleuth/probe-templates/${currentTemplate.id}/actions/run`,
+        `/toolkits/latency_sleuth/probe-templates/${currentTemplate.id}/actions/run`,
         { method: "POST", json: { sample_size: 3 } }
       );
       setJobId(response.job.id);
@@ -916,7 +916,7 @@ function LatencyHeatmapView() {
       setError(null);
       try {
         const response = await apiFetch(
-          `/toolkits/latency-sleuth/probe-templates/${currentTemplate.id}/heatmap`,
+          `/toolkits/latency_sleuth/probe-templates/${currentTemplate.id}/heatmap`,
           { method: "GET" }
         );
         if (!cancelled) {

--- a/toolkits/latency_sleuth/frontend/hooks/__tests__/useProbeTemplates.test.tsx
+++ b/toolkits/latency_sleuth/frontend/hooks/__tests__/useProbeTemplates.test.tsx
@@ -177,7 +177,7 @@ describe('useProbeTemplates', () => {
 
     const hook = renderHook(() => useProbeTemplates())
 
-    expect(apiFetch).toHaveBeenCalledWith('/toolkits/latency-sleuth/probe-templates', expect.any(Object))
+    expect(apiFetch).toHaveBeenCalledWith('/toolkits/latency_sleuth/probe-templates', expect.any(Object))
 
     await hook.result.current.refresh()
     hook.rerender()
@@ -232,7 +232,7 @@ describe('useProbeTemplates', () => {
     await hook.result.current.removeTemplate('generated')
     hook.rerender()
 
-    const deleteCall = apiFetch.mock.calls.find(([path]) => path === '/toolkits/latency-sleuth/probe-templates/generated')
+    const deleteCall = apiFetch.mock.calls.find(([path]) => path === '/toolkits/latency_sleuth/probe-templates/generated')
     expect(deleteCall).toBeTruthy()
     expect(deleteCall?.[1]?.method).toBe('DELETE')
     expect(hook.result.current.templates).toHaveLength(0)

--- a/toolkits/latency_sleuth/frontend/hooks/useJobStream.ts
+++ b/toolkits/latency_sleuth/frontend/hooks/useJobStream.ts
@@ -24,7 +24,7 @@ export function useJobStream(jobId: string | null, pollInterval = 2000) {
       setLoading(true)
       try {
         const response = await apiFetch<JobRecord>(
-          `/toolkits/latency-sleuth/jobs/${currentJobId}`,
+          `/toolkits/latency_sleuth/jobs/${currentJobId}`,
         )
         if (!activeRef.current) return response
         setJob(response)

--- a/toolkits/latency_sleuth/frontend/hooks/useProbeTemplates.ts
+++ b/toolkits/latency_sleuth/frontend/hooks/useProbeTemplates.ts
@@ -22,7 +22,7 @@ export function useProbeTemplates() {
     setError(null)
     try {
       const response = await apiFetch<ProbeTemplate[]>(
-        '/toolkits/latency-sleuth/probe-templates',
+        '/toolkits/latency_sleuth/probe-templates',
       )
       if (!activeRef.current) return
       response.sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
@@ -44,7 +44,7 @@ export function useProbeTemplates() {
   const createTemplate = useCallback(
     async (payload: ProbeTemplateCreate) => {
       const created = await apiFetch<ProbeTemplate>(
-        '/toolkits/latency-sleuth/probe-templates',
+        '/toolkits/latency_sleuth/probe-templates',
         { method: 'POST', json: payload },
       )
       if (activeRef.current) {
@@ -58,7 +58,7 @@ export function useProbeTemplates() {
   const updateTemplate = useCallback(
     async (templateId: string, payload: Partial<ProbeTemplateCreate>) => {
       const updated = await apiFetch<ProbeTemplate>(
-        `/toolkits/latency-sleuth/probe-templates/${templateId}`,
+        `/toolkits/latency_sleuth/probe-templates/${templateId}`,
         { method: 'PUT', json: payload },
       )
       if (activeRef.current) {
@@ -70,7 +70,7 @@ export function useProbeTemplates() {
   )
 
   const removeTemplate = useCallback(async (templateId: string) => {
-    await apiFetch(`/toolkits/latency-sleuth/probe-templates/${templateId}`, { method: 'DELETE' })
+    await apiFetch(`/toolkits/latency_sleuth/probe-templates/${templateId}`, { method: 'DELETE' })
     if (activeRef.current) {
       setTemplates((prev) => prev.filter((item) => item.id !== templateId))
     }

--- a/toolkits/latency_sleuth/frontend/hooks/useToolkitJobs.ts
+++ b/toolkits/latency_sleuth/frontend/hooks/useToolkitJobs.ts
@@ -27,7 +27,7 @@ export function useToolkitJobs(templateId: string | null, pollInterval = 10000) 
     setLoading(true)
     try {
       const response = await apiFetch<JobRecord[]>(
-        `/toolkits/latency-sleuth/jobs?template_id=${encodeURIComponent(templateId)}`,
+        `/toolkits/latency_sleuth/jobs?template_id=${encodeURIComponent(templateId)}`,
       )
       if (!activeRef.current) return response
       setJobs(response)

--- a/toolkits/latency_sleuth/toolkit.json
+++ b/toolkits/latency_sleuth/toolkit.json
@@ -10,7 +10,7 @@
     "tags": ["synthetic", "latency", "sla", "http", "probes"],
     "description": "Model web latency probes, tune SLAs, and visualise performance drift with synthetic checks."
   },
-  "base_path": "/toolkits/latency-sleuth",
+  "base_path": "/toolkits/latency_sleuth",
   "backend": {
     "module": "backend.app",
     "router_attr": "router"
@@ -32,7 +32,7 @@
       "title": "Synthetic Probes",
       "body": "Author SLA-aware HTTP probes, stream live latency telemetry, and wire alerts to on-call tools.",
       "link_text": "Launch",
-      "link_href": "/toolkits/latency-sleuth"
+      "link_href": "/toolkits/latency_sleuth"
     }
   ]
 }

--- a/toolkits/toolbox_health/docs/README.md
+++ b/toolkits/toolbox_health/docs/README.md
@@ -21,20 +21,20 @@ component status.
 
 ## Runtime expectations
 
-- FastAPI routes under `/toolkits/toolbox-health/health` serve component and
+- FastAPI routes under `/toolkits/toolbox_health/health` serve component and
   summary payloads sourced from `backend/health.py`.
 - Celery registration in `worker/tasks.py` schedules periodic refresh jobs to
   keep cached snapshots warm.
 - Dashboard context defined in `backend/dashboard.py` powers the React widgets
   bundled in `frontend/`.
-- Installation adds a dashboard card linking to `/toolkits/toolbox-health` in
+- Installation adds a dashboard card linking to `/toolkits/toolbox_health` in
   the Toolbox UI.
 
 ## Operator checklist
 
 1. Install the bundle via the admin UI or `/toolkits/install` API.
 2. Confirm the dashboard card renders and displays component status.
-3. Call `/toolkits/toolbox-health/health/summary?force_refresh=true` to validate
+3. Call `/toolkits/toolbox_health/health/summary?force_refresh=true` to validate
   backend refresh logic.
 4. Review Celery worker logs for refresh job execution and ensure metrics align
   with expectations.

--- a/toolkits/toolbox_health/docs/TESTING.md
+++ b/toolkits/toolbox_health/docs/TESTING.md
@@ -11,7 +11,7 @@
 3. Install the archive via the admin UI and open the Toolbox Health dashboard.
 4. Call the summary endpoint with a forced refresh:
    ```bash
-   curl "http://localhost:8000/toolkits/toolbox-health/health/summary?force_refresh=true"
+   curl "http://localhost:8000/toolkits/toolbox_health/health/summary?force_refresh=true"
    ```
    Confirm the response includes component entries with `status` and
    `latency_ms` fields.

--- a/toolkits/toolbox_health/frontend/dist/index.js
+++ b/toolkits/toolbox_health/frontend/dist/index.js
@@ -151,7 +151,7 @@ function OverviewPage() {
       try {
         const query = forceRefresh ? "?force_refresh=true" : "";
         const response = await apiFetch(
-          `/toolkits/toolbox-health/health/summary${query}`,
+          `/toolkits/toolbox_health/health/summary${query}`,
           {
             signal,
             cache: "no-store"

--- a/toolkits/toolbox_health/frontend/pages/OverviewPage.tsx
+++ b/toolkits/toolbox_health/frontend/pages/OverviewPage.tsx
@@ -142,7 +142,7 @@ export default function OverviewPage() {
       try {
         const query = forceRefresh ? '?force_refresh=true' : ''
         const response = await apiFetch<HealthSummary>(
-          `/toolkits/toolbox-health/health/summary${query}`,
+          `/toolkits/toolbox_health/health/summary${query}`,
           {
             signal,
             cache: 'no-store',

--- a/toolkits/toolbox_health/toolkit.json
+++ b/toolkits/toolbox_health/toolkit.json
@@ -9,7 +9,7 @@
     "tags": ["toolbox", "health", "status", "telemetry"],
     "description": "Monitor the Toolbox frontend, backend, and worker services."
   },
-  "base_path": "/toolkits/toolbox-health",
+  "base_path": "/toolkits/toolbox_health",
   "backend": {
     "module": "backend.app",
     "router_attr": "router"
@@ -31,7 +31,7 @@
       "title": "Toolbox Health",
       "body": "View the real-time status of the core Toolbox services.",
       "link_text": "Open",
-      "link_href": "/toolkits/toolbox-health",
+      "link_href": "/toolkits/toolbox_health",
       "icon": "stethoscope"
     }
   ]


### PR DESCRIPTION
## Summary
- align base_path and dashboard links for API Checker, Latency Sleuth, and Toolbox Health with their underscore slugs
- update toolkit frontends, backend tests, and docs to call the new underscore routes
- refresh the catalog manifest so docs and bundles point to the corrected paths

## Testing
- scripts/validate-repo.sh
- mkdocs build --strict --clean --site-dir site

------
https://chatgpt.com/codex/tasks/task_b_68d23e5e4cb08328a679a901e9f85c5b