### PR TITLE
Refine navigation menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full submission workflow.
 ## Support
 
 - Code of conduct: [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
-- Backlog and open questions: [`docs/TODO.yml`](docs/TODO.yml)
+- Backlog and open questions: docs/TODO.yml
 
 For help, open a discussion or issue using the templates in `.github/`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,5 +46,5 @@ mkdocs build --strict --clean --site-dir site
       `toolkit_bundle_service.py` instance.
 - [ ] Evidence from [testing](testing.md) attached to the pull request.
 
-Refer to the [task backlog](TODO.yml) for outstanding tasks and future
-automation ideas.
+Maintain outstanding tasks and future automation ideas in the internal
+backlog file `docs/TODO.yml`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,11 +14,9 @@ nav:
       - Toolkit authoring: toolkit-authoring.md
       - Testing checklist: testing.md
       - Contributor onboarding: onboarding.md
-      - Task backlog (TODO.yml): TODO.yml
       - Changelog: changelog.md
   - Toolkits:
       - Browse toolkits: toolkit-browser.md
-      - Regex Toolkit: toolkits/regex/index.md
       - Sample Diagnostics Toolkit: toolkits/sample-toolkit/index.md
 
 plugins:


### PR DESCRIPTION
## Summary
- simplify the documentation navigation by removing the TODO backlog entry and hiding individual toolkits
- keep the toolkits menu focused on browsing resources and the sample diagnostics toolkit
- refresh documentation references so the TODO backlog is mentioned without linking to the raw file

## Testing
- scripts/validate-repo.sh
- mkdocs build --strict --clean --site-dir site

------
https://chatgpt.com/codex/tasks/task_b_68d35aa87a4c8328a59b08c613105d8e