### PR TITLE
Fix subnet cheat sheet and sample toolkit frontend bundles

### DIFF
--- a/catalog/toolkits.json
+++ b/catalog/toolkits.json
@@ -88,7 +88,7 @@
     {
       "slug": "sample-toolkit",
       "name": "Sample Diagnostics Toolkit",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "description": "Reference implementation to help authors bootstrap new toolkits.",
       "tags": [
         "sample",
@@ -109,7 +109,7 @@
     {
       "slug": "subnet-cheatsheet",
       "name": "Subnet Calculator Toolkit",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "description": "IPv4 subnet calculator with ready-to-share prefix reference tables.",
       "tags": [
         "subnetting",

--- a/docs/catalog/toolkits.json
+++ b/docs/catalog/toolkits.json
@@ -88,7 +88,7 @@
     {
       "slug": "sample-toolkit",
       "name": "Sample Diagnostics Toolkit",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "description": "Reference implementation to help authors bootstrap new toolkits.",
       "tags": [
         "sample",
@@ -109,7 +109,7 @@
     {
       "slug": "subnet-cheatsheet",
       "name": "Subnet Calculator Toolkit",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "description": "IPv4 subnet calculator with ready-to-share prefix reference tables.",
       "tags": [
         "subnetting",

--- a/toolkits/sample-toolkit/docs/CHANGELOG.md
+++ b/toolkits/sample-toolkit/docs/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog – sample diagnostics toolkit
 
+## 0.1.1 – 2025-09-24
+- Bundle compiled frontend assets and runtime adapter so the panel renders in
+  the App Shell.
+
 ## 0.1.0 – 2025-09-22
 - Initial repository scaffold and validation example.

--- a/toolkits/sample-toolkit/docs/RELEASE_NOTES.md
+++ b/toolkits/sample-toolkit/docs/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release notes – sample diagnostics toolkit
 
+## 0.1.1
+- Bundled compiled React UI and runtime glue so the dashboard card renders in
+  the Toolbox shell.
+
 ## 0.1.0
 - Demonstrates required repository layout and validation workflow.
 - Bundler verified via `GET /toolkits/sample-toolkit/bundle.zip` with checksum capture.

--- a/toolkits/sample-toolkit/frontend/dist/index.js
+++ b/toolkits/sample-toolkit/frontend/dist/index.js
@@ -1,0 +1,23 @@
+function getToolkitRuntime() {
+  if (typeof window === "undefined" || !window.__SRE_TOOLKIT_RUNTIME) {
+    throw new Error("SRE Toolkit runtime not injected yet");
+  }
+  return window.__SRE_TOOLKIT_RUNTIME;
+}
+function getReactRuntime() {
+  return getToolkitRuntime().react;
+}
+const React = getReactRuntime();
+const SampleToolkitPanel = () =>
+  React.createElement(
+    "section",
+    { style: { padding: "1.5rem", color: "var(--color-text-primary)" } },
+    React.createElement("h1", null, "Sample Diagnostics Toolkit"),
+    React.createElement(
+      "p",
+      null,
+      "This placeholder panel confirms that front-end mounting works.",
+    ),
+  );
+export { SampleToolkitPanel };
+export default SampleToolkitPanel;

--- a/toolkits/sample-toolkit/frontend/index.tsx
+++ b/toolkits/sample-toolkit/frontend/index.tsx
@@ -1,6 +1,8 @@
-import React from "react";
+import { getReactRuntime } from "./runtime";
 
-export const SampleToolkitPanel: React.FC = () => {
+const React = getReactRuntime();
+
+export const SampleToolkitPanel = () => {
   return (
     <section>
       <h1>Sample Diagnostics Toolkit</h1>

--- a/toolkits/sample-toolkit/frontend/runtime.ts
+++ b/toolkits/sample-toolkit/frontend/runtime.ts
@@ -1,0 +1,22 @@
+import type * as ReactNamespace from 'react'
+
+export type ToolkitRuntime = {
+  react: typeof ReactNamespace
+}
+
+declare global {
+  interface Window {
+    __SRE_TOOLKIT_RUNTIME?: ToolkitRuntime
+  }
+}
+
+export function getToolkitRuntime(): ToolkitRuntime {
+  if (typeof window === 'undefined' || !window.__SRE_TOOLKIT_RUNTIME) {
+    throw new Error('SRE Toolkit runtime not injected yet')
+  }
+  return window.__SRE_TOOLKIT_RUNTIME
+}
+
+export function getReactRuntime() {
+  return getToolkitRuntime().react
+}

--- a/toolkits/sample-toolkit/toolkit.json
+++ b/toolkits/sample-toolkit/toolkit.json
@@ -1,7 +1,7 @@
 {
   "slug": "sample-toolkit",
   "name": "Sample Diagnostics Toolkit",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Reference toolkit showing directory structure and runtime entry points.",
   "backend": {
     "module": "backend.routes",
@@ -12,7 +12,8 @@
     "register_attr": "register"
   },
   "frontend": {
-    "entry": "frontend/index.tsx"
+    "entry": "frontend/dist/index.js",
+    "source_entry": "frontend/index.tsx"
   },
   "docs": {
     "overview": "docs/overview.md"

--- a/toolkits/subnet-cheatsheet/docs/BUILDING.md
+++ b/toolkits/subnet-cheatsheet/docs/BUILDING.md
@@ -1,0 +1,25 @@
+# Building the subnet calculator toolkit
+
+1. Compile the React panel to `frontend/dist/index.js`. Keep `react`,
+   `react-dom`, and `react-router-dom` external so the Toolbox shell provides
+   them at runtime. For example:
+   ```bash
+   pnpm exec esbuild toolkits/subnet-cheatsheet/frontend/index.tsx \
+     --bundle \
+     --format=esm \
+     --platform=browser \
+     --outfile=toolkits/subnet-cheatsheet/frontend/dist/index.js \
+     --external:react \
+     --external:react-dom \
+     --external:react-router-dom \
+     --loader:.ts=ts \
+     --loader:.tsx=tsx
+   ```
+2. Package the toolkit bundle:
+   ```bash
+   scripts/package-toolkit.sh subnet-cheatsheet
+   ```
+   The script regenerates documentation, validates the manifest, and writes a
+   timestamped ZIP archive to `dist/`.
+3. Upload the generated archive through **Administration → Toolkits** or by
+   calling the `/toolkits/install` API.

--- a/toolkits/subnet-cheatsheet/docs/CHANGELOG.md
+++ b/toolkits/subnet-cheatsheet/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.1
+
+- Ship compiled frontend assets and runtime glue so the calculator panel loads
+  in the App Shell.
+
 ## 0.1.0
 
 - Initial release of the subnet calculator toolkit.

--- a/toolkits/subnet-cheatsheet/docs/RELEASE_NOTES.md
+++ b/toolkits/subnet-cheatsheet/docs/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Release notes
 
+## 0.1.1
+
+- Bundled compiled React UI and runtime integration so the panel renders in the
+  Toolbox shell.
+
 ## 0.1.0
 
 - Initial release with IPv4 subnet summary endpoint, prefix table API, Celery

--- a/toolkits/subnet-cheatsheet/frontend/dist/index.js
+++ b/toolkits/subnet-cheatsheet/frontend/dist/index.js
@@ -1,0 +1,318 @@
+function getToolkitRuntime() {
+  if (typeof window === "undefined" || !window.__SRE_TOOLKIT_RUNTIME) {
+    throw new Error("SRE Toolkit runtime not injected yet");
+  }
+  return window.__SRE_TOOLKIT_RUNTIME;
+}
+function getReactRuntime() {
+  return getToolkitRuntime().react;
+}
+function apiFetch(path, options) {
+  return getToolkitRuntime().apiFetch(path, options);
+}
+const React = getReactRuntime();
+const { useCallback, useEffect, useMemo, useState } = React;
+const buildPrefixRow = (prefix) => {
+  const octetBits = [];
+  const octetValues = [];
+  for (let octetIndex = 0; octetIndex < 4; octetIndex += 1) {
+    const ones = Math.min(8, Math.max(0, prefix - octetIndex * 8));
+    const bitString = `${"1".repeat(ones)}${"0".repeat(8 - ones)}`;
+    octetBits.push(bitString);
+    octetValues.push(parseInt(bitString || "0", 2));
+  }
+  const netmask = octetValues.join(".");
+  const wildcardMask = octetValues.map((value) => 255 - value).join(".");
+  const binaryMask = octetBits.join(".");
+  const hostBits = Math.max(0, 32 - prefix);
+  const totalAddresses = prefix === 0 ? 2 ** 32 : 2 ** hostBits;
+  const usableHosts = prefix >= 31 ? totalAddresses : Math.max(totalAddresses - 2, 0);
+  return {
+    prefix,
+    cidr: `/${prefix}`,
+    netmask,
+    wildcardMask,
+    binaryMask,
+    totalAddresses,
+    usableHosts,
+  };
+};
+const DEFAULT_PREFIX_ROWS = Array.from({ length: 23 }, (_, index) => buildPrefixRow(index + 8));
+const formatNumber = (value) => value.toLocaleString();
+const DEFAULT_CIDR = "192.168.1.0/24";
+const formStyles = {
+  display: "grid",
+  gap: "0.75rem",
+  alignItems: "flex-start",
+  gridTemplateColumns: "minmax(0, 1fr)",
+  marginBottom: "1.5rem",
+};
+const formLabelStyles = {
+  display: "grid",
+  gap: "0.35rem",
+  color: "var(--color-text-primary)",
+};
+const inputStyles = {
+  padding: "0.65rem 0.75rem",
+  borderRadius: 8,
+  border: "1px solid var(--color-border)",
+  font: "inherit",
+};
+const buttonStyles = {
+  justifySelf: "start",
+  padding: "0.65rem 1rem",
+  borderRadius: 8,
+  border: "1px solid var(--color-border)",
+  background: "var(--color-accent)",
+  color: "var(--color-sidebar-item-active-text)",
+  fontWeight: 600,
+  cursor: "pointer",
+};
+const summaryStyles = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+  gap: "0.75rem",
+  marginBottom: "1.5rem",
+};
+const summaryItemStyles = {
+  padding: "0.75rem",
+  borderRadius: 10,
+  border: "1px solid var(--color-border)",
+  background: "var(--color-surface-alt)",
+  display: "grid",
+  gap: "0.25rem",
+};
+const summaryTermStyles = {
+  margin: 0,
+  fontSize: "0.85rem",
+  color: "var(--color-text-secondary)",
+};
+const summaryValueStyles = {
+  margin: 0,
+  fontSize: "1.1rem",
+  fontWeight: 600,
+};
+const tableStyles = {
+  width: "100%",
+  borderCollapse: "collapse",
+  marginTop: "1rem",
+};
+const tableHeaderStyles = {
+  textAlign: "left",
+  padding: "0.5rem 0.75rem",
+  borderBottom: "1px solid var(--color-border)",
+  fontSize: "0.85rem",
+  color: "var(--color-text-secondary)",
+};
+const tableCellStyles = {
+  padding: "0.6rem 0.75rem",
+  borderBottom: "1px solid var(--color-border)",
+  fontVariantNumeric: "tabular-nums",
+};
+const errorStyles = {
+  color: "var(--color-danger)",
+  fontWeight: 600,
+  marginBottom: "1rem",
+};
+const headerStyles = {
+  display: "grid",
+  gap: "0.5rem",
+  marginBottom: "1.5rem",
+};
+const sectionStyles = {
+  display: "grid",
+  color: "var(--color-text-primary)",
+  gap: "1.5rem",
+  padding: "1.5rem",
+};
+const tableWrapperStyles = {
+  overflowX: "auto",
+};
+const SubnetCheatSheetPanel = () => {
+  const [cidrInput, setCidrInput] = useState(DEFAULT_CIDR);
+  const [summary, setSummary] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const prefixRows = useMemo(() => DEFAULT_PREFIX_ROWS, []);
+  const fetchSummary = useCallback(async (cidr) => {
+    if (!cidr) {
+      setError("Provide a CIDR such as 10.0.0.0/24.");
+      setSummary(null);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const payload = await apiFetch(`/toolkits/subnet-cheatsheet/summary?cidr=${encodeURIComponent(cidr)}`);
+      setSummary(payload.summary);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Subnet lookup failed";
+      setError(message);
+      setSummary(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+  useEffect(() => {
+    void fetchSummary(DEFAULT_CIDR);
+  }, [fetchSummary]);
+  const handleSubmit = useCallback(
+    (event) => {
+      event.preventDefault();
+      void fetchSummary(cidrInput);
+    },
+    [cidrInput, fetchSummary],
+  );
+  return React.createElement(
+    "section",
+    { className: "subnet-cheat-sheet", style: sectionStyles },
+    React.createElement(
+      "header",
+      { style: headerStyles },
+      React.createElement("h1", null, "Subnet calculator"),
+      React.createElement(
+        "p",
+        null,
+        "Look up IPv4 ranges and compare prefix capacities without leaving the Toolbox.",
+      ),
+    ),
+    React.createElement(
+      "form",
+      { onSubmit: handleSubmit, className: "subnet-cheat-sheet__form", style: formStyles },
+      React.createElement(
+        "label",
+        { htmlFor: "subnet-cidr", style: formLabelStyles },
+        "CIDR network",
+        React.createElement("input", {
+          id: "subnet-cidr",
+          type: "text",
+          value: cidrInput,
+          onChange: (event) => setCidrInput(event.target.value),
+          placeholder: "10.10.42.0/24",
+          style: inputStyles,
+        }),
+      ),
+      React.createElement(
+        "button",
+        { type: "submit", disabled: loading, style: buttonStyles },
+        loading ? "Calculating…" : "Calculate",
+      ),
+    ),
+    error
+      ? React.createElement(
+          "p",
+          { role: "alert", className: "subnet-cheat-sheet__error", style: errorStyles },
+          error,
+        )
+      : null,
+    summary
+      ? React.createElement(
+          "dl",
+          { className: "subnet-cheat-sheet__summary", style: summaryStyles },
+          React.createElement(
+            "div",
+            { style: summaryItemStyles },
+            React.createElement("dt", { style: summaryTermStyles }, "Network"),
+            React.createElement("dd", { style: summaryValueStyles }, summary.network_address),
+          ),
+          React.createElement(
+            "div",
+            { style: summaryItemStyles },
+            React.createElement("dt", { style: summaryTermStyles }, "Broadcast"),
+            React.createElement("dd", { style: summaryValueStyles }, summary.broadcast_address),
+          ),
+          React.createElement(
+            "div",
+            { style: summaryItemStyles },
+            React.createElement("dt", { style: summaryTermStyles }, "First usable"),
+            React.createElement("dd", { style: summaryValueStyles }, summary.first_usable),
+          ),
+          React.createElement(
+            "div",
+            { style: summaryItemStyles },
+            React.createElement("dt", { style: summaryTermStyles }, "Last usable"),
+            React.createElement("dd", { style: summaryValueStyles }, summary.last_usable),
+          ),
+          React.createElement(
+            "div",
+            { style: summaryItemStyles },
+            React.createElement("dt", { style: summaryTermStyles }, "Wildcard"),
+            React.createElement("dd", { style: summaryValueStyles }, summary.wildcard_mask),
+          ),
+          React.createElement(
+            "div",
+            { style: summaryItemStyles },
+            React.createElement("dt", { style: summaryTermStyles }, "Netmask"),
+            React.createElement("dd", { style: summaryValueStyles }, summary.netmask),
+          ),
+          React.createElement(
+            "div",
+            { style: summaryItemStyles },
+            React.createElement("dt", { style: summaryTermStyles }, "Usable hosts"),
+            React.createElement("dd", { style: summaryValueStyles }, formatNumber(summary.usable_hosts)),
+          ),
+          React.createElement(
+            "div",
+            { style: summaryItemStyles },
+            React.createElement("dt", { style: summaryTermStyles }, "Total addresses"),
+            React.createElement("dd", { style: summaryValueStyles }, formatNumber(summary.total_addresses)),
+          ),
+          React.createElement(
+            "div",
+            { style: summaryItemStyles },
+            React.createElement("dt", { style: summaryTermStyles }, "Binary mask"),
+            React.createElement("dd", { style: summaryValueStyles }, React.createElement("code", null, summary.binary_mask)),
+          ),
+        )
+      : null,
+    React.createElement(
+      "section",
+      { className: "subnet-cheat-sheet__prefix-table", style: tableWrapperStyles },
+      React.createElement(
+        "h2",
+        null,
+        "Prefix cheat sheet",
+      ),
+      React.createElement(
+        "table",
+        { style: tableStyles },
+        React.createElement(
+          "thead",
+          null,
+          React.createElement(
+            "tr",
+            null,
+            React.createElement("th", { scope: "col", style: tableHeaderStyles }, "CIDR"),
+            React.createElement("th", { scope: "col", style: tableHeaderStyles }, "Netmask"),
+            React.createElement("th", { scope: "col", style: tableHeaderStyles }, "Wildcard"),
+            React.createElement("th", { scope: "col", style: tableHeaderStyles }, "Usable hosts"),
+            React.createElement("th", { scope: "col", style: tableHeaderStyles }, "Total addresses"),
+            React.createElement("th", { scope: "col", style: tableHeaderStyles }, "Binary mask"),
+          ),
+        ),
+        React.createElement(
+          "tbody",
+          null,
+          prefixRows.map((row) =>
+            React.createElement(
+              "tr",
+              { key: row.prefix },
+              React.createElement("th", { scope: "row", style: tableCellStyles }, row.cidr),
+              React.createElement("td", { style: tableCellStyles }, row.netmask),
+              React.createElement("td", { style: tableCellStyles }, row.wildcardMask),
+              React.createElement("td", { style: tableCellStyles }, formatNumber(row.usableHosts)),
+              React.createElement("td", { style: tableCellStyles }, formatNumber(row.totalAddresses)),
+              React.createElement(
+                "td",
+                { style: tableCellStyles },
+                React.createElement("code", null, row.binaryMask),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+};
+export { SubnetCheatSheetPanel };
+export default SubnetCheatSheetPanel;

--- a/toolkits/subnet-cheatsheet/frontend/index.tsx
+++ b/toolkits/subnet-cheatsheet/frontend/index.tsx
@@ -1,4 +1,9 @@
-import React, { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+import type { FormEvent } from "react";
+
+import { apiFetch, getReactRuntime } from "./runtime";
+
+const React = getReactRuntime();
+const { useCallback, useEffect, useMemo, useState } = React;
 
 type SubnetSummary = {
   cidr: string;
@@ -60,7 +65,7 @@ const formatNumber = (value: number) => value.toLocaleString();
 
 const DEFAULT_CIDR = "192.168.1.0/24";
 
-export const SubnetCheatSheetPanel: React.FC = () => {
+export const SubnetCheatSheetPanel = () => {
   const [cidrInput, setCidrInput] = useState(DEFAULT_CIDR);
   const [summary, setSummary] = useState<SubnetSummary | null>(null);
   const [loading, setLoading] = useState(false);
@@ -79,14 +84,9 @@ export const SubnetCheatSheetPanel: React.FC = () => {
     setError(null);
 
     try {
-      const response = await fetch(
+      const payload = await apiFetch<{ summary: SubnetSummary }>(
         `/toolkits/subnet-cheatsheet/summary?cidr=${encodeURIComponent(cidr)}`,
       );
-      if (!response.ok) {
-        const payload = (await response.json().catch(() => ({}))) as { detail?: string };
-        throw new Error(payload?.detail ?? "Subnet lookup failed");
-      }
-      const payload = (await response.json()) as { summary: SubnetSummary };
       setSummary(payload.summary);
     } catch (err) {
       const message = err instanceof Error ? err.message : "Subnet lookup failed";

--- a/toolkits/subnet-cheatsheet/frontend/runtime.ts
+++ b/toolkits/subnet-cheatsheet/frontend/runtime.ts
@@ -1,0 +1,29 @@
+import type * as ReactNamespace from 'react'
+import type * as ReactRouterDomNamespace from 'react-router-dom'
+
+export type ToolkitRuntime = {
+  react: typeof ReactNamespace
+  reactRouterDom: typeof ReactRouterDomNamespace
+  apiFetch: (path: string, options?: RequestInit & { json?: unknown }) => Promise<unknown>
+}
+
+declare global {
+  interface Window {
+    __SRE_TOOLKIT_RUNTIME?: ToolkitRuntime
+  }
+}
+
+export function getToolkitRuntime(): ToolkitRuntime {
+  if (typeof window === 'undefined' || !window.__SRE_TOOLKIT_RUNTIME) {
+    throw new Error('SRE Toolkit runtime not injected yet')
+  }
+  return window.__SRE_TOOLKIT_RUNTIME
+}
+
+export function getReactRuntime() {
+  return getToolkitRuntime().react
+}
+
+export function apiFetch<T = unknown>(path: string, options?: RequestInit & { json?: unknown }) {
+  return getToolkitRuntime().apiFetch(path, options) as Promise<T>
+}

--- a/toolkits/subnet-cheatsheet/toolkit.json
+++ b/toolkits/subnet-cheatsheet/toolkit.json
@@ -1,7 +1,7 @@
 {
   "slug": "subnet-cheatsheet",
   "name": "Subnet Calculator Toolkit",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Quickly compute IPv4 subnet details and browse a prefix cheat sheet.",
   "base_path": "/toolkits/subnet-cheatsheet",
   "backend": {
@@ -13,7 +13,8 @@
     "register_attr": "register"
   },
   "frontend": {
-    "entry": "frontend/index.tsx"
+    "entry": "frontend/dist/index.js",
+    "source_entry": "frontend/index.tsx"
   },
   "docs": {
     "overview": "docs/README.md"


### PR DESCRIPTION
## Summary
- compile-ready frontend runtime helpers and bundled JS for the subnet cheat sheet so the App Shell can load it
- add the same runtime adapter to the sample toolkit and publish prebuilt assets for parity
- document the build workflow and bump catalog metadata/changelogs to 0.1.1 for both toolkits

## Testing
- `./scripts/validate-repo.sh`
- `mkdocs build --strict --clean --site-dir site`


------
https://chatgpt.com/codex/tasks/task_b_68d378e885b8832893b61e229ba6897f