### PR TITLE
Fix subnet cheat sheet API route mounting

### DIFF
--- a/ai/ops/codex.md
+++ b/ai/ops/codex.md
@@ -10,6 +10,7 @@ You are Codex, a large language model assisting with the SRE Toolbox community r
 4. Run `scripts/validate-repo.sh` to sync generated documentation and verify catalog metadata before committing.
 5. Update `docs/TODO.yaml`, `ai/state/progress.json`, and `ai/state/journal.md` after each session.
 6. Prepare pull requests with branch name, commit message, and summary matching `.github/PULL_REQUEST_TEMPLATE.md` expectations.
+7. Bump the `version` field in each affected `toolkits/<slug>/toolkit.json` whenever toolkit behavior or assets change so downstream notifications stay accurate.
 
 ## Notes
 

--- a/catalog/toolkits.json
+++ b/catalog/toolkits.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2025-09-24T04:21:22Z",
+  "generated_at": "2025-09-24T05:22:19Z",
   "toolkits": [
     {
       "slug": "api_checker",
@@ -109,7 +109,7 @@
     {
       "slug": "subnet-cheatsheet",
       "name": "Subnet Calculator Toolkit",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "description": "IPv4 subnet calculator with ready-to-share prefix reference tables.",
       "tags": [
         "subnetting",

--- a/docs/catalog/toolkits.json
+++ b/docs/catalog/toolkits.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2025-09-24T04:21:22Z",
+  "generated_at": "2025-09-24T05:22:19Z",
   "toolkits": [
     {
       "slug": "api_checker",
@@ -109,7 +109,7 @@
     {
       "slug": "subnet-cheatsheet",
       "name": "Subnet Calculator Toolkit",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "description": "IPv4 subnet calculator with ready-to-share prefix reference tables.",
       "tags": [
         "subnetting",

--- a/toolkits/subnet-cheatsheet/backend/app.py
+++ b/toolkits/subnet-cheatsheet/backend/app.py
@@ -10,7 +10,7 @@ def create_app() -> FastAPI:
     """Return a FastAPI application that mounts the subnet routes."""
 
     application = FastAPI(title="Subnet cheat sheet toolkit")
-    application.include_router(router)
+    application.include_router(router, prefix="/toolkits/subnet-cheatsheet")
     return application
 
 

--- a/toolkits/subnet-cheatsheet/backend/routes.py
+++ b/toolkits/subnet-cheatsheet/backend/routes.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, HTTPException, Query
 
 from .calculator import generate_prefix_table, parse_network, summarize_subnet
 
-router = APIRouter(prefix="/toolkits/subnet-cheatsheet", tags=["subnet-cheatsheet"])
+router = APIRouter(tags=["subnet-cheatsheet"])
 
 
 @router.get("/summary")

--- a/toolkits/subnet-cheatsheet/toolkit.json
+++ b/toolkits/subnet-cheatsheet/toolkit.json
@@ -1,7 +1,7 @@
 {
   "slug": "subnet-cheatsheet",
   "name": "Subnet Calculator Toolkit",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Quickly compute IPv4 subnet details and browse a prefix cheat sheet.",
   "base_path": "/toolkits/subnet-cheatsheet",
   "backend": {


### PR DESCRIPTION
## Summary
- remove the hard-coded prefix from the subnet cheat sheet FastAPI router so the control plane can mount it correctly
- include the expected /toolkits/subnet-cheatsheet prefix when wiring the router in the local create_app factory

## Testing
- scripts/validate-repo.sh
- mkdocs build --strict --clean --site-dir site

------
https://chatgpt.com/codex/tasks/task_b_68d37e4025c4832882ba5b400eb912ec