### PR TITLE
Split subnet calculator into dedicated toolkit pages

### DIFF
--- a/catalog/toolkits.json
+++ b/catalog/toolkits.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2025-09-24T05:22:19Z",
+  "generated_at": "2025-10-01T04:28:43Z",
   "toolkits": [
     {
       "slug": "api_checker",
@@ -109,7 +109,7 @@
     {
       "slug": "subnet-cheatsheet",
       "name": "Subnet Calculator Toolkit",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "description": "IPv4 subnet calculator with ready-to-share prefix reference tables.",
       "tags": [
         "subnetting",

--- a/docs/catalog/toolkits.json
+++ b/docs/catalog/toolkits.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2025-09-24T05:22:19Z",
+  "generated_at": "2025-10-01T04:28:43Z",
   "toolkits": [
     {
       "slug": "api_checker",
@@ -109,7 +109,7 @@
     {
       "slug": "subnet-cheatsheet",
       "name": "Subnet Calculator Toolkit",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "description": "IPv4 subnet calculator with ready-to-share prefix reference tables.",
       "tags": [
         "subnetting",

--- a/docs/toolkits/subnet-cheatsheet/index.md
+++ b/docs/toolkits/subnet-cheatsheet/index.md
@@ -9,14 +9,16 @@ title: Subnet Calculator toolkit
 The subnet calculator toolkit gives operators a quick way to inspect IPv4
 subnets and share an accompanying prefix cheat sheet. Use the built-in API to
 calculate ranges for ad-hoc troubleshooting or schedule the bundled Celery tasks
-when you want fresh data in dashboards.
+when you want fresh data in dashboards. The toolkit now ships with dedicated
+pages for the calculator and prefix reference so operators can jump directly to
+the view they need.
 
 ## What ships in the bundle
 
 - FastAPI router mounted at `/toolkits/subnet-cheatsheet` with endpoints for
   ad-hoc subnet summaries and prefix tables.
 - Celery helpers that expose the same calculations for asynchronous workflows.
-- Lightweight React panel that renders a lookup form together with a
+- Lightweight React interface with navigation between the calculator and the
   ready-to-share prefix table.
 
 ## Validate the bundle
@@ -41,4 +43,5 @@ when you want fresh data in dashboards.
 2. Upload it through the Toolbox admin UI.
 3. Call `/toolkits/subnet-cheatsheet/summary?cidr=192.168.1.0/24` to confirm the
    API responds with the expected subnet details.
-4. Visit the App Shell dashboard card to confirm the calculator panel renders.
+4. Visit the App Shell dashboard card to confirm the calculator panel renders,
+   then switch to the "Prefix cheat sheet" tab to validate the table view.

--- a/toolkits/subnet-cheatsheet/docs/CHANGELOG.md
+++ b/toolkits/subnet-cheatsheet/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.0
+
+- Split the IPv4 calculator and prefix reference into separate pages with
+  in-tool navigation.
+
 ## 0.1.1
 
 - Ship compiled frontend assets and runtime glue so the calculator panel loads

--- a/toolkits/subnet-cheatsheet/docs/README.md
+++ b/toolkits/subnet-cheatsheet/docs/README.md
@@ -3,14 +3,16 @@
 The subnet calculator toolkit gives operators a quick way to inspect IPv4
 subnets and share an accompanying prefix cheat sheet. Use the built-in API to
 calculate ranges for ad-hoc troubleshooting or schedule the bundled Celery tasks
-when you want fresh data in dashboards.
+when you want fresh data in dashboards. The toolkit now ships with dedicated
+pages for the calculator and prefix reference so operators can jump directly to
+the view they need.
 
 ## What ships in the bundle
 
 - FastAPI router mounted at `/toolkits/subnet-cheatsheet` with endpoints for
   ad-hoc subnet summaries and prefix tables.
 - Celery helpers that expose the same calculations for asynchronous workflows.
-- Lightweight React panel that renders a lookup form together with a
+- Lightweight React interface with navigation between the calculator and the
   ready-to-share prefix table.
 
 ## Validate the bundle
@@ -35,4 +37,5 @@ when you want fresh data in dashboards.
 2. Upload it through the Toolbox admin UI.
 3. Call `/toolkits/subnet-cheatsheet/summary?cidr=192.168.1.0/24` to confirm the
    API responds with the expected subnet details.
-4. Visit the App Shell dashboard card to confirm the calculator panel renders.
+4. Visit the App Shell dashboard card to confirm the calculator panel renders,
+   then switch to the "Prefix cheat sheet" tab to validate the table view.

--- a/toolkits/subnet-cheatsheet/docs/RELEASE_NOTES.md
+++ b/toolkits/subnet-cheatsheet/docs/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Release notes
 
+## 0.2.0
+
+- Introduced navigation that separates the IPv4 calculator and prefix cheat
+  sheet into dedicated pages.
+
 ## 0.1.1
 
 - Bundled compiled React UI and runtime integration so the panel renders in the

--- a/toolkits/subnet-cheatsheet/frontend/dist/index.js
+++ b/toolkits/subnet-cheatsheet/frontend/dist/index.js
@@ -10,8 +10,13 @@ function getReactRuntime() {
 function apiFetch(path, options) {
   return getToolkitRuntime().apiFetch(path, options);
 }
+function getReactRouterRuntime() {
+  return getToolkitRuntime().reactRouterDom;
+}
 const React = getReactRuntime();
+const Router = getReactRouterRuntime();
 const { useCallback, useEffect, useMemo, useState } = React;
+const { NavLink, Navigate, Route, Routes } = Router;
 const buildPrefixRow = (prefix) => {
   const octetBits = [];
   const octetValues = [];
@@ -40,100 +45,15 @@ const buildPrefixRow = (prefix) => {
 const DEFAULT_PREFIX_ROWS = Array.from({ length: 23 }, (_, index) => buildPrefixRow(index + 8));
 const formatNumber = (value) => value.toLocaleString();
 const DEFAULT_CIDR = "192.168.1.0/24";
-const formStyles = {
-  display: "grid",
-  gap: "0.75rem",
-  alignItems: "flex-start",
-  gridTemplateColumns: "minmax(0, 1fr)",
-  marginBottom: "1.5rem",
-};
-const formLabelStyles = {
-  display: "grid",
-  gap: "0.35rem",
-  color: "var(--color-text-primary)",
-};
-const inputStyles = {
-  padding: "0.65rem 0.75rem",
-  borderRadius: 8,
-  border: "1px solid var(--color-border)",
-  font: "inherit",
-};
-const buttonStyles = {
-  justifySelf: "start",
-  padding: "0.65rem 1rem",
-  borderRadius: 8,
-  border: "1px solid var(--color-border)",
-  background: "var(--color-accent)",
-  color: "var(--color-sidebar-item-active-text)",
-  fontWeight: 600,
-  cursor: "pointer",
-};
-const summaryStyles = {
-  display: "grid",
-  gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
-  gap: "0.75rem",
-  marginBottom: "1.5rem",
-};
-const summaryItemStyles = {
-  padding: "0.75rem",
-  borderRadius: 10,
-  border: "1px solid var(--color-border)",
-  background: "var(--color-surface-alt)",
-  display: "grid",
-  gap: "0.25rem",
-};
-const summaryTermStyles = {
-  margin: 0,
-  fontSize: "0.85rem",
-  color: "var(--color-text-secondary)",
-};
-const summaryValueStyles = {
-  margin: 0,
-  fontSize: "1.1rem",
-  fontWeight: 600,
-};
-const tableStyles = {
-  width: "100%",
-  borderCollapse: "collapse",
-  marginTop: "1rem",
-};
-const tableHeaderStyles = {
-  textAlign: "left",
-  padding: "0.5rem 0.75rem",
-  borderBottom: "1px solid var(--color-border)",
-  fontSize: "0.85rem",
-  color: "var(--color-text-secondary)",
-};
-const tableCellStyles = {
-  padding: "0.6rem 0.75rem",
-  borderBottom: "1px solid var(--color-border)",
-  fontVariantNumeric: "tabular-nums",
-};
-const errorStyles = {
-  color: "var(--color-danger)",
-  fontWeight: 600,
-  marginBottom: "1rem",
-};
-const headerStyles = {
-  display: "grid",
-  gap: "0.5rem",
-  marginBottom: "1.5rem",
-};
-const sectionStyles = {
-  display: "grid",
-  color: "var(--color-text-primary)",
-  gap: "1.5rem",
-  padding: "1.5rem",
-};
-const tableWrapperStyles = {
-  overflowX: "auto",
-};
-const SubnetCheatSheetPanel = () => {
+const navLinkClassName = ({ isActive }) =>
+  isActive
+    ? "subnet-cheat-sheet__nav-link subnet-cheat-sheet__nav-link--active"
+    : "subnet-cheat-sheet__nav-link";
+const CalculatorPage = () => {
   const [cidrInput, setCidrInput] = useState(DEFAULT_CIDR);
   const [summary, setSummary] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
-  const prefixRows = useMemo(() => DEFAULT_PREFIX_ROWS, []);
   const fetchSummary = useCallback(async (cidr) => {
     if (!cidr) {
       setError("Provide a CIDR such as 10.0.0.0/24.");
@@ -164,24 +84,14 @@ const SubnetCheatSheetPanel = () => {
     [cidrInput, fetchSummary],
   );
   return React.createElement(
-    "section",
-    { className: "subnet-cheat-sheet", style: sectionStyles },
-    React.createElement(
-      "header",
-      { style: headerStyles },
-      React.createElement("h1", null, "Subnet calculator"),
-      React.createElement(
-        "p",
-        null,
-        "Look up IPv4 ranges and compare prefix capacities without leaving the Toolbox.",
-      ),
-    ),
+    "div",
+    { className: "subnet-cheat-sheet__calculator" },
     React.createElement(
       "form",
-      { onSubmit: handleSubmit, className: "subnet-cheat-sheet__form", style: formStyles },
+      { onSubmit: handleSubmit, className: "subnet-cheat-sheet__form" },
       React.createElement(
         "label",
-        { htmlFor: "subnet-cidr", style: formLabelStyles },
+        { htmlFor: "subnet-cidr" },
         "CIDR network",
         React.createElement("input", {
           id: "subnet-cidr",
@@ -189,127 +99,153 @@ const SubnetCheatSheetPanel = () => {
           value: cidrInput,
           onChange: (event) => setCidrInput(event.target.value),
           placeholder: "10.10.42.0/24",
-          style: inputStyles,
         }),
       ),
       React.createElement(
         "button",
-        { type: "submit", disabled: loading, style: buttonStyles },
+        { type: "submit", disabled: loading },
         loading ? "Calculating…" : "Calculate",
       ),
     ),
     error
       ? React.createElement(
           "p",
-          { role: "alert", className: "subnet-cheat-sheet__error", style: errorStyles },
+          { role: "alert", className: "subnet-cheat-sheet__error" },
           error,
         )
       : null,
     summary
       ? React.createElement(
           "dl",
-          { className: "subnet-cheat-sheet__summary", style: summaryStyles },
+          { className: "subnet-cheat-sheet__summary" },
           React.createElement(
             "div",
-            { style: summaryItemStyles },
-            React.createElement("dt", { style: summaryTermStyles }, "Network"),
-            React.createElement("dd", { style: summaryValueStyles }, summary.network_address),
+            null,
+            React.createElement("dt", null, "Network"),
+            React.createElement("dd", null, summary.network_address),
           ),
           React.createElement(
             "div",
-            { style: summaryItemStyles },
-            React.createElement("dt", { style: summaryTermStyles }, "Broadcast"),
-            React.createElement("dd", { style: summaryValueStyles }, summary.broadcast_address),
+            null,
+            React.createElement("dt", null, "Broadcast"),
+            React.createElement("dd", null, summary.broadcast_address),
           ),
           React.createElement(
             "div",
-            { style: summaryItemStyles },
-            React.createElement("dt", { style: summaryTermStyles }, "First usable"),
-            React.createElement("dd", { style: summaryValueStyles }, summary.first_usable),
+            null,
+            React.createElement("dt", null, "First usable"),
+            React.createElement("dd", null, summary.first_usable),
           ),
           React.createElement(
             "div",
-            { style: summaryItemStyles },
-            React.createElement("dt", { style: summaryTermStyles }, "Last usable"),
-            React.createElement("dd", { style: summaryValueStyles }, summary.last_usable),
+            null,
+            React.createElement("dt", null, "Last usable"),
+            React.createElement("dd", null, summary.last_usable),
           ),
           React.createElement(
             "div",
-            { style: summaryItemStyles },
-            React.createElement("dt", { style: summaryTermStyles }, "Wildcard"),
-            React.createElement("dd", { style: summaryValueStyles }, summary.wildcard_mask),
+            null,
+            React.createElement("dt", null, "Netmask"),
+            React.createElement("dd", null, summary.netmask),
           ),
           React.createElement(
             "div",
-            { style: summaryItemStyles },
-            React.createElement("dt", { style: summaryTermStyles }, "Netmask"),
-            React.createElement("dd", { style: summaryValueStyles }, summary.netmask),
+            null,
+            React.createElement("dt", null, "Wildcard mask"),
+            React.createElement("dd", null, summary.wildcard_mask),
           ),
           React.createElement(
             "div",
-            { style: summaryItemStyles },
-            React.createElement("dt", { style: summaryTermStyles }, "Usable hosts"),
-            React.createElement("dd", { style: summaryValueStyles }, formatNumber(summary.usable_hosts)),
+            null,
+            React.createElement("dt", null, "Usable hosts"),
+            React.createElement("dd", null, formatNumber(summary.usable_hosts)),
           ),
           React.createElement(
             "div",
-            { style: summaryItemStyles },
-            React.createElement("dt", { style: summaryTermStyles }, "Total addresses"),
-            React.createElement("dd", { style: summaryValueStyles }, formatNumber(summary.total_addresses)),
-          ),
-          React.createElement(
-            "div",
-            { style: summaryItemStyles },
-            React.createElement("dt", { style: summaryTermStyles }, "Binary mask"),
-            React.createElement("dd", { style: summaryValueStyles }, React.createElement("code", null, summary.binary_mask)),
+            null,
+            React.createElement("dt", null, "Total addresses"),
+            React.createElement("dd", null, formatNumber(summary.total_addresses)),
           ),
         )
       : null,
+  );
+};
+const PrefixCheatSheetPage = () => {
+  const prefixRows = useMemo(() => DEFAULT_PREFIX_ROWS, []);
+  return React.createElement(
+    "section",
+    { className: "subnet-cheat-sheet__table" },
+    React.createElement("h2", null, "Prefix cheat sheet"),
     React.createElement(
-      "section",
-      { className: "subnet-cheat-sheet__prefix-table", style: tableWrapperStyles },
+      "p",
+      null,
+      "Use this table to compare prefix capacities, netmasks, and wildcard masks when planning address allocations.",
+    ),
+    React.createElement(
+      "table",
+      null,
       React.createElement(
-        "h2",
+        "thead",
         null,
-        "Prefix cheat sheet",
+        React.createElement(
+          "tr",
+          null,
+          React.createElement("th", { scope: "col" }, "CIDR"),
+          React.createElement("th", { scope: "col" }, "Netmask"),
+          React.createElement("th", { scope: "col" }, "Wildcard"),
+          React.createElement("th", { scope: "col" }, "Usable hosts"),
+          React.createElement("th", { scope: "col" }, "Total addresses"),
+          React.createElement("th", { scope: "col" }, "Binary mask"),
+        ),
       ),
       React.createElement(
-        "table",
-        { style: tableStyles },
-        React.createElement(
-          "thead",
-          null,
+        "tbody",
+        null,
+        prefixRows.map((row) =>
           React.createElement(
             "tr",
-            null,
-            React.createElement("th", { scope: "col", style: tableHeaderStyles }, "CIDR"),
-            React.createElement("th", { scope: "col", style: tableHeaderStyles }, "Netmask"),
-            React.createElement("th", { scope: "col", style: tableHeaderStyles }, "Wildcard"),
-            React.createElement("th", { scope: "col", style: tableHeaderStyles }, "Usable hosts"),
-            React.createElement("th", { scope: "col", style: tableHeaderStyles }, "Total addresses"),
-            React.createElement("th", { scope: "col", style: tableHeaderStyles }, "Binary mask"),
+            { key: row.prefix },
+            React.createElement("th", { scope: "row" }, row.cidr),
+            React.createElement("td", null, row.netmask),
+            React.createElement("td", null, row.wildcardMask),
+            React.createElement("td", null, formatNumber(row.usableHosts)),
+            React.createElement("td", null, formatNumber(row.totalAddresses)),
+            React.createElement("td", null, React.createElement("code", null, row.binaryMask)),
           ),
         ),
-        React.createElement(
-          "tbody",
-          null,
-          prefixRows.map((row) =>
-            React.createElement(
-              "tr",
-              { key: row.prefix },
-              React.createElement("th", { scope: "row", style: tableCellStyles }, row.cidr),
-              React.createElement("td", { style: tableCellStyles }, row.netmask),
-              React.createElement("td", { style: tableCellStyles }, row.wildcardMask),
-              React.createElement("td", { style: tableCellStyles }, formatNumber(row.usableHosts)),
-              React.createElement("td", { style: tableCellStyles }, formatNumber(row.totalAddresses)),
-              React.createElement(
-                "td",
-                { style: tableCellStyles },
-                React.createElement("code", null, row.binaryMask),
-              ),
-            ),
-          ),
-        ),
+      ),
+    ),
+  );
+};
+const SubnetCheatSheetPanel = () => {
+  return React.createElement(
+    "section",
+    { className: "subnet-cheat-sheet" },
+    React.createElement(
+      "header",
+      null,
+      React.createElement("h1", null, "Subnet toolkit"),
+      React.createElement(
+        "p",
+        null,
+        "Switch between the IPv4 calculator and the prefix reference without leaving the Toolbox.",
+      ),
+    ),
+    React.createElement(
+      "nav",
+      { className: "subnet-cheat-sheet__nav", "aria-label": "Subnet toolkit sections" },
+      React.createElement(NavLink, { end: true, to: "", className: navLinkClassName }, "Calculator"),
+      React.createElement(NavLink, { to: "cheat-sheet", className: navLinkClassName }, "Prefix cheat sheet"),
+    ),
+    React.createElement(
+      "div",
+      { className: "subnet-cheat-sheet__content" },
+      React.createElement(
+        Routes,
+        null,
+        React.createElement(Route, { index: true, element: React.createElement(CalculatorPage, null) }),
+        React.createElement(Route, { path: "cheat-sheet", element: React.createElement(PrefixCheatSheetPage, null) }),
+        React.createElement(Route, { path: "*", element: React.createElement(Navigate, { to: ".", replace: true }) }),
       ),
     ),
   );

--- a/toolkits/subnet-cheatsheet/frontend/runtime.ts
+++ b/toolkits/subnet-cheatsheet/frontend/runtime.ts
@@ -27,3 +27,7 @@ export function getReactRuntime() {
 export function apiFetch<T = unknown>(path: string, options?: RequestInit & { json?: unknown }) {
   return getToolkitRuntime().apiFetch(path, options) as Promise<T>
 }
+
+export function getReactRouterRuntime() {
+  return getToolkitRuntime().reactRouterDom
+}

--- a/toolkits/subnet-cheatsheet/toolkit.json
+++ b/toolkits/subnet-cheatsheet/toolkit.json
@@ -1,7 +1,7 @@
 {
   "slug": "subnet-cheatsheet",
   "name": "Subnet Calculator Toolkit",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Quickly compute IPv4 subnet details and browse a prefix cheat sheet.",
   "base_path": "/toolkits/subnet-cheatsheet",
   "backend": {


### PR DESCRIPTION
## Summary
- add router-based navigation so the calculator and prefix cheat sheet render on separate pages
- document the UI split, bump the subnet-cheatsheet toolkit to version 0.2.0, and refresh catalog metadata

## Testing
- `scripts/validate-repo.sh`
- `mkdocs build --strict --clean --site-dir site`


------
https://chatgpt.com/codex/tasks/task_b_68dcacfc2d088328ab1ef79e082819b2