### PR TITLE
Refresh subnet toolkit styling and bump version

### DIFF
--- a/ai/state/journal.md
+++ b/ai/state/journal.md
@@ -23,3 +23,8 @@ Use this file to capture session-level notes. Each entry should record tasks att
 - Populated catalog metadata blocks (version, categories, tags, maintainers) for recently documented toolkits and normalized slugs to underscore style.
 - Regenerated catalog/toolkits.json via sync script; validate_catalog and validate-repo succeed with python3 alias workaround.
 - mkdocs build --strict still fails locally because mkdocs is not installed; captured as follow-up for dependency pinning.
+
+## 2025-10-01 Subnet toolkit refresh
+- Restyled the Subnet toolkit panel to use shared card patterns, iconography, and inline styles consistent with Latency Sleuth.
+- Added inline calculator/table refinements for better readability and responsive layout, including loading and error affordances.
+- Bumped the toolkit manifest to version 0.3.0 and updated AI state to record the release.

--- a/ai/state/progress.json
+++ b/ai/state/progress.json
@@ -1,14 +1,15 @@
 {
   "version": 1,
-  "last_updated": "2025-09-23T05:32:10Z",
-  "session_counter": 4,
+  "last_updated": "2025-10-01T05:25:00Z",
+  "session_counter": 5,
   "active_task": null,
-  "last_task_id": "catalog-metadata-backfill",
+  "last_task_id": "subnet-cheatsheet-refresh",
   "recent_updates": [
     "Populated catalog metadata (version, categories, tags, maintainers) in manifests for API Checker, Connectivity, Latency Sleuth, Toolbox Health, and Zabbix; synced catalog and docs; mkdocs build still blocked by missing mkdocs binary.",
     "Audited community toolkits, added missing README/BUILDING/TESTING/CHANGELOG/RELEASE_NOTES files, synced generated docs, and captured validation blockers for templates and MkDocs.",
     "Ran scripts/validate-repo.sh successfully; mkdocs build blocked by missing MkDocs dependency.",
-    "Captured documentation-site backlog items to pin MkDocs requirements and add CI coverage."
+    "Captured documentation-site backlog items to pin MkDocs requirements and add CI coverage.",
+    "Refined the Subnet toolkit UI to align with shared styling, bumped the manifest to 0.3.0, and documented the refresh."
   ],
   "candidate_next_tasks": [
     "Capture MkDocs dependency requirements",

--- a/catalog/toolkits.json
+++ b/catalog/toolkits.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2025-10-01T04:28:43Z",
+  "generated_at": "2025-10-01T05:17:26Z",
   "toolkits": [
     {
       "slug": "api_checker",
@@ -109,7 +109,7 @@
     {
       "slug": "subnet-cheatsheet",
       "name": "Subnet Calculator Toolkit",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "description": "IPv4 subnet calculator with ready-to-share prefix reference tables.",
       "tags": [
         "subnetting",

--- a/docs/catalog/toolkits.json
+++ b/docs/catalog/toolkits.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2025-10-01T04:28:43Z",
+  "generated_at": "2025-10-01T05:17:26Z",
   "toolkits": [
     {
       "slug": "api_checker",
@@ -109,7 +109,7 @@
     {
       "slug": "subnet-cheatsheet",
       "name": "Subnet Calculator Toolkit",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "description": "IPv4 subnet calculator with ready-to-share prefix reference tables.",
       "tags": [
         "subnetting",

--- a/toolkits/subnet-cheatsheet/frontend/dist/index.js
+++ b/toolkits/subnet-cheatsheet/frontend/dist/index.js
@@ -4,19 +4,173 @@ function getToolkitRuntime() {
   }
   return window.__SRE_TOOLKIT_RUNTIME;
 }
+
 function getReactRuntime() {
   return getToolkitRuntime().react;
 }
+
 function apiFetch(path, options) {
   return getToolkitRuntime().apiFetch(path, options);
 }
+
 function getReactRouterRuntime() {
   return getToolkitRuntime().reactRouterDom;
 }
+
 const React = getReactRuntime();
 const Router = getReactRouterRuntime();
 const { useCallback, useEffect, useMemo, useState } = React;
 const { NavLink, Navigate, Route, Routes } = Router;
+
+const containerStyle = {
+  padding: "1.5rem",
+  display: "grid",
+  gap: "1.5rem",
+  color: "var(--color-text-primary)",
+};
+
+const headerTitleStyle = {
+  margin: 0,
+  display: "flex",
+  alignItems: "center",
+  gap: "0.5rem",
+};
+
+const headerSubtitleStyle = {
+  margin: "0.35rem 0 0",
+  color: "var(--color-text-secondary)",
+};
+
+const navStyle = {
+  display: "flex",
+  gap: "0.75rem",
+  flexWrap: "wrap",
+};
+
+const navLinkStyle = (active) => ({
+  padding: "0.5rem 0.85rem",
+  borderRadius: 8,
+  border: "1px solid var(--color-border)",
+  textDecoration: "none",
+  background: active ? "var(--color-accent)" : "transparent",
+  color: active ? "var(--color-sidebar-item-active-text)" : "var(--color-link)",
+  fontWeight: 600,
+  display: "inline-flex",
+  alignItems: "center",
+  gap: "0.5rem",
+});
+
+const contentStyle = {
+  display: "grid",
+  gap: "1.5rem",
+};
+
+const sectionStyle = {
+  display: "grid",
+  gap: "1rem",
+};
+
+const formStyle = {
+  display: "grid",
+  gap: "1rem",
+  alignItems: "end",
+  gridTemplateColumns: "minmax(0, 1fr) auto",
+};
+
+const labelStyle = {
+  display: "grid",
+  gap: "0.35rem",
+  fontWeight: 600,
+  color: "var(--color-text-secondary)",
+};
+
+const inputStyle = {
+  background: "var(--color-surface-muted)",
+  border: "1px solid var(--color-border)",
+  borderRadius: 8,
+  color: "var(--color-text-primary)",
+  padding: "0.65rem 0.75rem",
+  font: "inherit",
+};
+
+const statusRowStyle = {
+  display: "flex",
+  gap: "0.75rem",
+  alignItems: "center",
+  flexWrap: "wrap",
+};
+
+const errorStyle = {
+  color: "var(--color-status-error)",
+  margin: 0,
+};
+
+const summaryStyle = {
+  display: "grid",
+  gap: "0.75rem",
+  gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+  margin: 0,
+};
+
+const summaryCardStyle = {
+  background: "var(--color-surface-muted)",
+  padding: "0.75rem",
+  borderRadius: 10,
+  display: "grid",
+  gap: "0.35rem",
+};
+
+const summaryTermStyle = {
+  margin: 0,
+  color: "var(--color-text-secondary)",
+  fontSize: "0.85rem",
+  textTransform: "uppercase",
+  letterSpacing: "0.05em",
+};
+
+const summaryValueStyle = {
+  margin: 0,
+  fontWeight: 600,
+};
+
+const tableSectionStyle = {
+  display: "grid",
+  gap: "0.75rem",
+};
+
+const tableIntroStyle = {
+  margin: "0.25rem 0 0",
+  color: "var(--color-text-secondary)",
+};
+
+const tableWrapperStyle = {
+  overflowX: "auto",
+};
+
+const tableStyle = {
+  width: "100%",
+  borderCollapse: "collapse",
+  minWidth: 480,
+};
+
+const tableHeaderCellStyle = {
+  textAlign: "left",
+  padding: "0.65rem",
+  fontSize: "0.85rem",
+  color: "var(--color-text-secondary)",
+  borderBottom: "1px solid var(--color-border)",
+};
+
+const tableCellStyle = {
+  padding: "0.65rem",
+  borderBottom: "1px solid var(--color-border)",
+};
+
+const codeStyle = {
+  fontFamily: "var(--font-mono)",
+  fontSize: "0.85rem",
+};
+
 const buildPrefixRow = (prefix) => {
   const octetBits = [];
   const octetValues = [];
@@ -42,26 +196,27 @@ const buildPrefixRow = (prefix) => {
     usableHosts,
   };
 };
+
 const DEFAULT_PREFIX_ROWS = Array.from({ length: 23 }, (_, index) => buildPrefixRow(index + 8));
 const formatNumber = (value) => value.toLocaleString();
 const DEFAULT_CIDR = "192.168.1.0/24";
-const navLinkClassName = ({ isActive }) =>
-  isActive
-    ? "subnet-cheat-sheet__nav-link subnet-cheat-sheet__nav-link--active"
-    : "subnet-cheat-sheet__nav-link";
+
 const CalculatorPage = () => {
   const [cidrInput, setCidrInput] = useState(DEFAULT_CIDR);
   const [summary, setSummary] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+
   const fetchSummary = useCallback(async (cidr) => {
     if (!cidr) {
       setError("Provide a CIDR such as 10.0.0.0/24.");
       setSummary(null);
       return;
     }
+
     setLoading(true);
     setError(null);
+
     try {
       const payload = await apiFetch(`/toolkits/subnet-cheatsheet/summary?cidr=${encodeURIComponent(cidr)}`);
       setSummary(payload.summary);
@@ -73,9 +228,11 @@ const CalculatorPage = () => {
       setLoading(false);
     }
   }, []);
+
   useEffect(() => {
     void fetchSummary(DEFAULT_CIDR);
   }, [fetchSummary]);
+
   const handleSubmit = useCallback(
     (event) => {
       event.preventDefault();
@@ -83,15 +240,39 @@ const CalculatorPage = () => {
     },
     [cidrInput, fetchSummary],
   );
+
+  const summaryItems = summary
+    ? [
+        { label: "Network", value: summary.network_address },
+        { label: "Broadcast", value: summary.broadcast_address },
+        { label: "First usable", value: summary.first_usable },
+        { label: "Last usable", value: summary.last_usable },
+        { label: "Netmask", value: summary.netmask },
+        { label: "Wildcard mask", value: summary.wildcard_mask },
+        { label: "Usable hosts", value: formatNumber(summary.usable_hosts) },
+        { label: "Total addresses", value: formatNumber(summary.total_addresses) },
+      ]
+    : null;
+
   return React.createElement(
-    "div",
-    { className: "subnet-cheat-sheet__calculator" },
+    "section",
+    { className: "tk-card", style: sectionStyle },
+    React.createElement(
+      "header",
+      null,
+      React.createElement("h3", { style: { margin: 0 } }, "IPv4 calculator"),
+      React.createElement(
+        "p",
+        { style: tableIntroStyle },
+        "Compute broadcast, mask, and usable range details for any CIDR.",
+      ),
+    ),
     React.createElement(
       "form",
-      { onSubmit: handleSubmit, className: "subnet-cheat-sheet__form" },
+      { onSubmit: handleSubmit, style: formStyle },
       React.createElement(
         "label",
-        { htmlFor: "subnet-cidr" },
+        { htmlFor: "subnet-cidr", style: labelStyle },
         "CIDR network",
         React.createElement("input", {
           id: "subnet-cidr",
@@ -99,147 +280,161 @@ const CalculatorPage = () => {
           value: cidrInput,
           onChange: (event) => setCidrInput(event.target.value),
           placeholder: "10.10.42.0/24",
+          style: inputStyle,
         }),
       ),
       React.createElement(
         "button",
-        { type: "submit", disabled: loading },
+        { type: "submit", className: "tk-button tk-button--primary", disabled: loading },
         loading ? "Calculating…" : "Calculate",
       ),
     ),
-    error
-      ? React.createElement(
-          "p",
-          { role: "alert", className: "subnet-cheat-sheet__error" },
-          error,
-        )
-      : null,
-    summary
+    React.createElement(
+      "div",
+      { style: statusRowStyle },
+      loading
+        ? React.createElement("span", { style: { color: "var(--color-text-secondary)" } }, "Fetching subnet data…")
+        : null,
+      error
+        ? React.createElement(
+            "p",
+            { role: "alert", style: errorStyle },
+            error,
+          )
+        : null,
+    ),
+    summaryItems
       ? React.createElement(
           "dl",
-          { className: "subnet-cheat-sheet__summary" },
-          React.createElement(
-            "div",
-            null,
-            React.createElement("dt", null, "Network"),
-            React.createElement("dd", null, summary.network_address),
-          ),
-          React.createElement(
-            "div",
-            null,
-            React.createElement("dt", null, "Broadcast"),
-            React.createElement("dd", null, summary.broadcast_address),
-          ),
-          React.createElement(
-            "div",
-            null,
-            React.createElement("dt", null, "First usable"),
-            React.createElement("dd", null, summary.first_usable),
-          ),
-          React.createElement(
-            "div",
-            null,
-            React.createElement("dt", null, "Last usable"),
-            React.createElement("dd", null, summary.last_usable),
-          ),
-          React.createElement(
-            "div",
-            null,
-            React.createElement("dt", null, "Netmask"),
-            React.createElement("dd", null, summary.netmask),
-          ),
-          React.createElement(
-            "div",
-            null,
-            React.createElement("dt", null, "Wildcard mask"),
-            React.createElement("dd", null, summary.wildcard_mask),
-          ),
-          React.createElement(
-            "div",
-            null,
-            React.createElement("dt", null, "Usable hosts"),
-            React.createElement("dd", null, formatNumber(summary.usable_hosts)),
-          ),
-          React.createElement(
-            "div",
-            null,
-            React.createElement("dt", null, "Total addresses"),
-            React.createElement("dd", null, formatNumber(summary.total_addresses)),
+          { style: summaryStyle },
+          summaryItems.map((item) =>
+            React.createElement(
+              "div",
+              { key: item.label, style: summaryCardStyle },
+              React.createElement("dt", { style: summaryTermStyle }, item.label),
+              React.createElement("dd", { style: summaryValueStyle }, item.value),
+            ),
           ),
         )
       : null,
   );
 };
+
 const PrefixCheatSheetPage = () => {
   const prefixRows = useMemo(() => DEFAULT_PREFIX_ROWS, []);
+
   return React.createElement(
     "section",
-    { className: "subnet-cheat-sheet__table" },
-    React.createElement("h2", null, "Prefix cheat sheet"),
-    React.createElement(
-      "p",
-      null,
-      "Use this table to compare prefix capacities, netmasks, and wildcard masks when planning address allocations.",
-    ),
-    React.createElement(
-      "table",
-      null,
-      React.createElement(
-        "thead",
-        null,
-        React.createElement(
-          "tr",
-          null,
-          React.createElement("th", { scope: "col" }, "CIDR"),
-          React.createElement("th", { scope: "col" }, "Netmask"),
-          React.createElement("th", { scope: "col" }, "Wildcard"),
-          React.createElement("th", { scope: "col" }, "Usable hosts"),
-          React.createElement("th", { scope: "col" }, "Total addresses"),
-          React.createElement("th", { scope: "col" }, "Binary mask"),
-        ),
-      ),
-      React.createElement(
-        "tbody",
-        null,
-        prefixRows.map((row) =>
-          React.createElement(
-            "tr",
-            { key: row.prefix },
-            React.createElement("th", { scope: "row" }, row.cidr),
-            React.createElement("td", null, row.netmask),
-            React.createElement("td", null, row.wildcardMask),
-            React.createElement("td", null, formatNumber(row.usableHosts)),
-            React.createElement("td", null, formatNumber(row.totalAddresses)),
-            React.createElement("td", null, React.createElement("code", null, row.binaryMask)),
-          ),
-        ),
-      ),
-    ),
-  );
-};
-const SubnetCheatSheetPanel = () => {
-  return React.createElement(
-    "section",
-    { className: "subnet-cheat-sheet" },
+    { className: "tk-card", style: tableSectionStyle },
     React.createElement(
       "header",
       null,
-      React.createElement("h1", null, "Subnet toolkit"),
+      React.createElement("h3", { style: { margin: 0 } }, "Prefix cheat sheet"),
       React.createElement(
         "p",
-        null,
+        { style: tableIntroStyle },
+        "Use this table to compare prefix capacities, netmasks, and wildcard masks when planning address allocations.",
+      ),
+    ),
+    React.createElement(
+      "div",
+      { style: tableWrapperStyle },
+      React.createElement(
+        "table",
+        { style: tableStyle },
+        React.createElement(
+          "thead",
+          null,
+          React.createElement(
+            "tr",
+            null,
+            React.createElement("th", { scope: "col", style: tableHeaderCellStyle }, "CIDR"),
+            React.createElement("th", { scope: "col", style: tableHeaderCellStyle }, "Netmask"),
+            React.createElement("th", { scope: "col", style: tableHeaderCellStyle }, "Wildcard"),
+            React.createElement("th", { scope: "col", style: tableHeaderCellStyle }, "Usable hosts"),
+            React.createElement("th", { scope: "col", style: tableHeaderCellStyle }, "Total addresses"),
+            React.createElement("th", { scope: "col", style: tableHeaderCellStyle }, "Binary mask"),
+          ),
+        ),
+        React.createElement(
+          "tbody",
+          null,
+          prefixRows.map((row) =>
+            React.createElement(
+              "tr",
+              { key: row.prefix },
+              React.createElement(
+                "th",
+                { scope: "row", style: Object.assign({}, tableCellStyle, { fontWeight: 600 }) },
+                row.cidr,
+              ),
+              React.createElement("td", { style: tableCellStyle }, row.netmask),
+              React.createElement("td", { style: tableCellStyle }, row.wildcardMask),
+              React.createElement("td", { style: tableCellStyle }, formatNumber(row.usableHosts)),
+              React.createElement("td", { style: tableCellStyle }, formatNumber(row.totalAddresses)),
+              React.createElement(
+                "td",
+                { style: tableCellStyle },
+                React.createElement("code", { style: codeStyle }, row.binaryMask),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+};
+
+const SubnetCheatSheetPanel = () =>
+  React.createElement(
+    "section",
+    { className: "tk-card", style: containerStyle },
+    React.createElement(
+      "header",
+      null,
+      React.createElement(
+        "h2",
+        { style: headerTitleStyle },
+        React.createElement(
+          "span",
+          { className: "material-symbols-outlined", "aria-hidden": true },
+          "dns",
+        ),
+        "Subnet toolkit",
+      ),
+      React.createElement(
+        "p",
+        { style: headerSubtitleStyle },
         "Switch between the IPv4 calculator and the prefix reference without leaving the Toolbox.",
       ),
     ),
     React.createElement(
       "nav",
-      { className: "subnet-cheat-sheet__nav", "aria-label": "Subnet toolkit sections" },
-      React.createElement(NavLink, { end: true, to: "", className: navLinkClassName }, "Calculator"),
-      React.createElement(NavLink, { to: "cheat-sheet", className: navLinkClassName }, "Prefix cheat sheet"),
+      { style: navStyle, "aria-label": "Subnet toolkit sections" },
+      React.createElement(
+        NavLink,
+        { end: true, to: "", style: ({ isActive }) => navLinkStyle(isActive) },
+        React.createElement(
+          "span",
+          { className: "material-symbols-outlined", "aria-hidden": true },
+          "calculate",
+        ),
+        "Calculator",
+      ),
+      React.createElement(
+        NavLink,
+        { to: "cheat-sheet", style: ({ isActive }) => navLinkStyle(isActive) },
+        React.createElement(
+          "span",
+          { className: "material-symbols-outlined", "aria-hidden": true },
+          "table",
+        ),
+        "Prefix cheat sheet",
+      ),
     ),
     React.createElement(
       "div",
-      { className: "subnet-cheat-sheet__content" },
+      { style: contentStyle },
       React.createElement(
         Routes,
         null,
@@ -249,6 +444,5 @@ const SubnetCheatSheetPanel = () => {
       ),
     ),
   );
-};
-export { SubnetCheatSheetPanel };
-export default SubnetCheatSheetPanel;
+
+export { SubnetCheatSheetPanel as default };

--- a/toolkits/subnet-cheatsheet/frontend/index.tsx
+++ b/toolkits/subnet-cheatsheet/frontend/index.tsx
@@ -1,4 +1,4 @@
-import type { FormEvent } from "react";
+import type { CSSProperties, FormEvent } from "react";
 
 import { apiFetch, getReactRouterRuntime, getReactRuntime } from "./runtime";
 
@@ -6,6 +6,155 @@ const React = getReactRuntime();
 const Router = getReactRouterRuntime();
 const { useCallback, useEffect, useMemo, useState } = React;
 const { NavLink, Navigate, Route, Routes } = Router;
+
+const containerStyle: CSSProperties = {
+  padding: "1.5rem",
+  display: "grid",
+  gap: "1.5rem",
+  color: "var(--color-text-primary)",
+};
+
+const headerTitleStyle: CSSProperties = {
+  margin: 0,
+  display: "flex",
+  alignItems: "center",
+  gap: "0.5rem",
+};
+
+const headerSubtitleStyle: CSSProperties = {
+  margin: "0.35rem 0 0",
+  color: "var(--color-text-secondary)",
+};
+
+const navStyle: CSSProperties = {
+  display: "flex",
+  gap: "0.75rem",
+  flexWrap: "wrap",
+};
+
+const navLinkStyle = (active: boolean): CSSProperties => ({
+  padding: "0.5rem 0.85rem",
+  borderRadius: 8,
+  border: "1px solid var(--color-border)",
+  textDecoration: "none",
+  background: active ? "var(--color-accent)" : "transparent",
+  color: active ? "var(--color-sidebar-item-active-text)" : "var(--color-link)",
+  fontWeight: 600,
+  display: "inline-flex",
+  alignItems: "center",
+  gap: "0.5rem",
+});
+
+const contentStyle: CSSProperties = {
+  display: "grid",
+  gap: "1.5rem",
+};
+
+const sectionStyle: CSSProperties = {
+  display: "grid",
+  gap: "1rem",
+};
+
+const formStyle: CSSProperties = {
+  display: "grid",
+  gap: "1rem",
+  alignItems: "end",
+  gridTemplateColumns: "minmax(0, 1fr) auto",
+};
+
+const labelStyle: CSSProperties = {
+  display: "grid",
+  gap: "0.35rem",
+  fontWeight: 600,
+  color: "var(--color-text-secondary)",
+};
+
+const inputStyle: CSSProperties = {
+  background: "var(--color-surface-muted)",
+  border: "1px solid var(--color-border)",
+  borderRadius: 8,
+  color: "var(--color-text-primary)",
+  padding: "0.65rem 0.75rem",
+  font: "inherit",
+};
+
+const statusRowStyle: CSSProperties = {
+  display: "flex",
+  gap: "0.75rem",
+  alignItems: "center",
+  flexWrap: "wrap",
+};
+
+const errorStyle: CSSProperties = {
+  color: "var(--color-status-error)",
+  margin: 0,
+};
+
+const summaryStyle: CSSProperties = {
+  display: "grid",
+  gap: "0.75rem",
+  gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+  margin: 0,
+};
+
+const summaryCardStyle: CSSProperties = {
+  background: "var(--color-surface-muted)",
+  padding: "0.75rem",
+  borderRadius: 10,
+  display: "grid",
+  gap: "0.35rem",
+};
+
+const summaryTermStyle: CSSProperties = {
+  margin: 0,
+  color: "var(--color-text-secondary)",
+  fontSize: "0.85rem",
+  textTransform: "uppercase",
+  letterSpacing: "0.05em",
+};
+
+const summaryValueStyle: CSSProperties = {
+  margin: 0,
+  fontWeight: 600,
+};
+
+const tableSectionStyle: CSSProperties = {
+  display: "grid",
+  gap: "0.75rem",
+};
+
+const tableIntroStyle: CSSProperties = {
+  margin: "0.25rem 0 0",
+  color: "var(--color-text-secondary)",
+};
+
+const tableWrapperStyle: CSSProperties = {
+  overflowX: "auto",
+};
+
+const tableStyle: CSSProperties = {
+  width: "100%",
+  borderCollapse: "collapse",
+  minWidth: 480,
+};
+
+const tableHeaderCellStyle: CSSProperties = {
+  textAlign: "left",
+  padding: "0.65rem",
+  fontSize: "0.85rem",
+  color: "var(--color-text-secondary)",
+  borderBottom: "1px solid var(--color-border)",
+};
+
+const tableCellStyle: CSSProperties = {
+  padding: "0.65rem",
+  borderBottom: "1px solid var(--color-border)",
+};
+
+const codeStyle: CSSProperties = {
+  fontFamily: "var(--font-mono)",
+  fontSize: "0.85rem",
+};
 
 type SubnetSummary = {
   cidr: string;
@@ -67,11 +216,6 @@ const formatNumber = (value: number) => value.toLocaleString();
 
 const DEFAULT_CIDR = "192.168.1.0/24";
 
-const navLinkClassName = ({ isActive }: { isActive: boolean }) =>
-  isActive
-    ? "subnet-cheat-sheet__nav-link subnet-cheat-sheet__nav-link--active"
-    : "subnet-cheat-sheet__nav-link";
-
 const CalculatorPage = () => {
   const [cidrInput, setCidrInput] = useState(DEFAULT_CIDR);
   const [summary, setSummary] = useState<SubnetSummary | null>(null);
@@ -114,10 +258,30 @@ const CalculatorPage = () => {
     [cidrInput, fetchSummary],
   );
 
+  const summaryItems = summary
+    ? (
+        [
+          { label: "Network", value: summary.network_address },
+          { label: "Broadcast", value: summary.broadcast_address },
+          { label: "First usable", value: summary.first_usable },
+          { label: "Last usable", value: summary.last_usable },
+          { label: "Netmask", value: summary.netmask },
+          { label: "Wildcard mask", value: summary.wildcard_mask },
+          { label: "Usable hosts", value: formatNumber(summary.usable_hosts) },
+          { label: "Total addresses", value: formatNumber(summary.total_addresses) },
+        ] satisfies Array<{ label: string; value: string }>
+      )
+    : null;
+
   return (
-    <div className="subnet-cheat-sheet__calculator">
-      <form onSubmit={handleSubmit} className="subnet-cheat-sheet__form">
-        <label htmlFor="subnet-cidr">
+    <section className="tk-card" style={sectionStyle}>
+      <header>
+        <h3 style={{ margin: 0 }}>IPv4 calculator</h3>
+        <p style={tableIntroStyle}>Compute broadcast, mask, and usable range details for any CIDR.</p>
+      </header>
+
+      <form onSubmit={handleSubmit} style={formStyle}>
+        <label htmlFor="subnet-cidr" style={labelStyle}>
           CIDR network
           <input
             id="subnet-cidr"
@@ -125,56 +289,34 @@ const CalculatorPage = () => {
             value={cidrInput}
             onChange={(event) => setCidrInput(event.target.value)}
             placeholder="10.10.42.0/24"
+            style={inputStyle}
           />
         </label>
-        <button type="submit" disabled={loading}>
+        <button type="submit" className="tk-button tk-button--primary" disabled={loading}>
           {loading ? "Calculating…" : "Calculate"}
         </button>
       </form>
 
-      {error ? (
-        <p role="alert" className="subnet-cheat-sheet__error">
-          {error}
-        </p>
-      ) : null}
+      <div style={statusRowStyle}>
+        {loading ? <span style={{ color: "var(--color-text-secondary)" }}>Fetching subnet data…</span> : null}
+        {error ? (
+          <p role="alert" style={errorStyle}>
+            {error}
+          </p>
+        ) : null}
+      </div>
 
-      {summary ? (
-        <dl className="subnet-cheat-sheet__summary">
-          <div>
-            <dt>Network</dt>
-            <dd>{summary.network_address}</dd>
-          </div>
-          <div>
-            <dt>Broadcast</dt>
-            <dd>{summary.broadcast_address}</dd>
-          </div>
-          <div>
-            <dt>First usable</dt>
-            <dd>{summary.first_usable}</dd>
-          </div>
-          <div>
-            <dt>Last usable</dt>
-            <dd>{summary.last_usable}</dd>
-          </div>
-          <div>
-            <dt>Netmask</dt>
-            <dd>{summary.netmask}</dd>
-          </div>
-          <div>
-            <dt>Wildcard mask</dt>
-            <dd>{summary.wildcard_mask}</dd>
-          </div>
-          <div>
-            <dt>Usable hosts</dt>
-            <dd>{formatNumber(summary.usable_hosts)}</dd>
-          </div>
-          <div>
-            <dt>Total addresses</dt>
-            <dd>{formatNumber(summary.total_addresses)}</dd>
-          </div>
+      {summaryItems ? (
+        <dl style={summaryStyle}>
+          {summaryItems.map((item) => (
+            <div key={item.label} style={summaryCardStyle}>
+              <dt style={summaryTermStyle}>{item.label}</dt>
+              <dd style={summaryValueStyle}>{item.value}</dd>
+            </div>
+          ))}
         </dl>
       ) : null}
-    </div>
+    </section>
   );
 };
 
@@ -182,63 +324,91 @@ const PrefixCheatSheetPage = () => {
   const prefixRows = useMemo(() => DEFAULT_PREFIX_ROWS, []);
 
   return (
-    <section className="subnet-cheat-sheet__table">
-      <h2>Prefix cheat sheet</h2>
-      <p>
-        Use this table to compare prefix capacities, netmasks, and wildcard
-        masks when planning address allocations.
-      </p>
-      <table>
-        <thead>
-          <tr>
-            <th scope="col">CIDR</th>
-            <th scope="col">Netmask</th>
-            <th scope="col">Wildcard</th>
-            <th scope="col">Usable hosts</th>
-            <th scope="col">Total addresses</th>
-            <th scope="col">Binary mask</th>
-          </tr>
-        </thead>
-        <tbody>
-          {prefixRows.map((row) => (
-            <tr key={row.prefix}>
-              <th scope="row">{row.cidr}</th>
-              <td>{row.netmask}</td>
-              <td>{row.wildcardMask}</td>
-              <td>{formatNumber(row.usableHosts)}</td>
-              <td>{formatNumber(row.totalAddresses)}</td>
-              <td>
-                <code>{row.binaryMask}</code>
-              </td>
+    <section className="tk-card" style={tableSectionStyle}>
+      <header>
+        <h3 style={{ margin: 0 }}>Prefix cheat sheet</h3>
+        <p style={tableIntroStyle}>
+          Use this table to compare prefix capacities, netmasks, and wildcard masks when planning address allocations.
+        </p>
+      </header>
+
+      <div style={tableWrapperStyle}>
+        <table style={tableStyle}>
+          <thead>
+            <tr>
+              <th scope="col" style={tableHeaderCellStyle}>
+                CIDR
+              </th>
+              <th scope="col" style={tableHeaderCellStyle}>
+                Netmask
+              </th>
+              <th scope="col" style={tableHeaderCellStyle}>
+                Wildcard
+              </th>
+              <th scope="col" style={tableHeaderCellStyle}>
+                Usable hosts
+              </th>
+              <th scope="col" style={tableHeaderCellStyle}>
+                Total addresses
+              </th>
+              <th scope="col" style={tableHeaderCellStyle}>
+                Binary mask
+              </th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {prefixRows.map((row) => (
+              <tr key={row.prefix}>
+                <th scope="row" style={{ ...tableCellStyle, fontWeight: 600 }}>
+                  {row.cidr}
+                </th>
+                <td style={tableCellStyle}>{row.netmask}</td>
+                <td style={tableCellStyle}>{row.wildcardMask}</td>
+                <td style={tableCellStyle}>{formatNumber(row.usableHosts)}</td>
+                <td style={tableCellStyle}>{formatNumber(row.totalAddresses)}</td>
+                <td style={tableCellStyle}>
+                  <code style={codeStyle}>{row.binaryMask}</code>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </section>
   );
 };
 
 export const SubnetCheatSheetPanel = () => {
   return (
-    <section className="subnet-cheat-sheet">
+    <section className="tk-card" style={containerStyle}>
       <header>
-        <h1>Subnet toolkit</h1>
-        <p>
-          Switch between the IPv4 calculator and the prefix reference without
-          leaving the Toolbox.
+        <h2 style={headerTitleStyle}>
+          <span className="material-symbols-outlined" aria-hidden>
+            dns
+          </span>
+          Subnet toolkit
+        </h2>
+        <p style={headerSubtitleStyle}>
+          Switch between the IPv4 calculator and the prefix reference without leaving the Toolbox.
         </p>
       </header>
 
-      <nav className="subnet-cheat-sheet__nav" aria-label="Subnet toolkit sections">
-        <NavLink end to="" className={navLinkClassName}>
+      <nav style={navStyle} aria-label="Subnet toolkit sections">
+        <NavLink end to="" style={({ isActive }) => navLinkStyle(isActive)}>
+          <span className="material-symbols-outlined" aria-hidden>
+            calculate
+          </span>
           Calculator
         </NavLink>
-        <NavLink to="cheat-sheet" className={navLinkClassName}>
+        <NavLink to="cheat-sheet" style={({ isActive }) => navLinkStyle(isActive)}>
+          <span className="material-symbols-outlined" aria-hidden>
+            table
+          </span>
           Prefix cheat sheet
         </NavLink>
       </nav>
 
-      <div className="subnet-cheat-sheet__content">
+      <div style={contentStyle}>
         <Routes>
           <Route index element={<CalculatorPage />} />
           <Route path="cheat-sheet" element={<PrefixCheatSheetPage />} />

--- a/toolkits/subnet-cheatsheet/toolkit.json
+++ b/toolkits/subnet-cheatsheet/toolkit.json
@@ -1,7 +1,7 @@
 {
   "slug": "subnet-cheatsheet",
   "name": "Subnet Calculator Toolkit",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Quickly compute IPv4 subnet details and browse a prefix cheat sheet.",
   "base_path": "/toolkits/subnet-cheatsheet",
   "backend": {


### PR DESCRIPTION
## Summary
- restyle the subnet toolkit panel to use shared card layouts, icon badges, and inline styling aligned with other toolkits
- refine the IPv4 calculator and prefix cheat sheet experiences with responsive grids, loading states, and improved table legibility
- bump the subnet-cheatsheet toolkit to version 0.3.0 and sync catalog plus AI progress records

## Testing
- scripts/validate-repo.sh
- mkdocs build --strict --clean --site-dir site

------
https://chatgpt.com/codex/tasks/task_b_68dcb859d02883289b9e4d9320024221