### PR TITLE
Add TLS Watchtower certificate monitoring toolkit

### DIFF
--- a/ai/state/journal.md
+++ b/ai/state/journal.md
@@ -28,3 +28,8 @@ Use this file to capture session-level notes. Each entry should record tasks att
 - Restyled the Subnet toolkit panel to use shared card patterns, iconography, and inline styles consistent with Latency Sleuth.
 - Added inline calculator/table refinements for better readability and responsive layout, including loading and error affordances.
 - Bumped the toolkit manifest to version 0.3.0 and updated AI state to record the release.
+
+## 2025-10-01 TLS Watchtower toolkit bootstrap
+- Built the TLS Watchtower bundle with FastAPI scan routes, Celery sweep/retry tasks, and a seeded in-memory store.
+- Authored React dashboard assets, documentation set, and updated changelog plus catalog metadata for the new toolkit.
+

--- a/ai/state/progress.json
+++ b/ai/state/progress.json
@@ -1,15 +1,15 @@
 {
   "version": 1,
-  "last_updated": "2025-10-01T05:25:00Z",
-  "session_counter": 5,
+  "last_updated": "2025-10-01T08:00:00Z",
+  "session_counter": 6,
   "active_task": null,
-  "last_task_id": "subnet-cheatsheet-refresh",
+  "last_task_id": "tls-watchtower-bootstrap",
   "recent_updates": [
-    "Populated catalog metadata (version, categories, tags, maintainers) in manifests for API Checker, Connectivity, Latency Sleuth, Toolbox Health, and Zabbix; synced catalog and docs; mkdocs build still blocked by missing mkdocs binary.",
     "Audited community toolkits, added missing README/BUILDING/TESTING/CHANGELOG/RELEASE_NOTES files, synced generated docs, and captured validation blockers for templates and MkDocs.",
     "Ran scripts/validate-repo.sh successfully; mkdocs build blocked by missing MkDocs dependency.",
     "Captured documentation-site backlog items to pin MkDocs requirements and add CI coverage.",
-    "Refined the Subnet toolkit UI to align with shared styling, bumped the manifest to 0.3.0, and documented the refresh."
+    "Refined the Subnet toolkit UI to align with shared styling, bumped the manifest to 0.3.0, and documented the refresh.",
+    "Delivered the TLS Watchtower toolkit with FastAPI scan routes, Celery sweep tasks, seeded hosts, and a React dashboard; catalog docs and changelog refreshed."
   ],
   "candidate_next_tasks": [
     "Capture MkDocs dependency requirements",

--- a/catalog/toolkits.json
+++ b/catalog/toolkits.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2025-10-01T05:17:26Z",
+  "generated_at": "2025-10-01T06:02:46Z",
   "toolkits": [
     {
       "slug": "api_checker",
@@ -125,6 +125,27 @@
       "categories": [
         "Networking",
         "Diagnostics"
+      ]
+    },
+    {
+      "slug": "tls-watchtower",
+      "name": "TLS Watchtower",
+      "version": "0.1.0",
+      "description": "Monitor SSL/TLS certificate expirations, queue renewals, and surface red/yellow/green dashboards.",
+      "tags": [
+        "tls",
+        "certificates",
+        "observability"
+      ],
+      "maintainers": [
+        "toolbox-maintainers@example.com"
+      ],
+      "source": "toolkits/tls-watchtower",
+      "docs_url": "toolkits/tls-watchtower/",
+      "bundle_url": "toolkits/tls-watchtower/bundle.zip",
+      "categories": [
+        "Security",
+        "Monitoring"
       ]
     },
     {

--- a/docs/TODO.yml
+++ b/docs/TODO.yml
@@ -1,5 +1,5 @@
 version: 1
-updated: 2025-09-23
+updated: 2025-10-01
 owners:
   - team: sre-toolbox
   - ai: codex
@@ -69,3 +69,14 @@ areas:
         title: Add CI coverage that runs mkdocs build --strict to catch missing dependencies.
         status: backlog
         priority: medium
+  - id: community-toolkits
+    title: Community toolkit development
+    summary: Tracking new toolkit contributions requested by maintainers.
+    tasks:
+      - id: tls-watchtower-bootstrap
+        title: Add TLS Watchtower certificate monitoring toolkit to the catalog.
+        status: done
+        priority: high
+        notes:
+          - "2025-10-01: Implemented FastAPI endpoints, Celery jobs, seeded hosts, and React dashboard for TLS Watchtower."
+

--- a/docs/catalog/toolkits.json
+++ b/docs/catalog/toolkits.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generated_at": "2025-10-01T05:17:26Z",
+  "generated_at": "2025-10-01T06:02:46Z",
   "toolkits": [
     {
       "slug": "api_checker",
@@ -125,6 +125,27 @@
       "categories": [
         "Networking",
         "Diagnostics"
+      ]
+    },
+    {
+      "slug": "tls-watchtower",
+      "name": "TLS Watchtower",
+      "version": "0.1.0",
+      "description": "Monitor SSL/TLS certificate expirations, queue renewals, and surface red/yellow/green dashboards.",
+      "tags": [
+        "tls",
+        "certificates",
+        "observability"
+      ],
+      "maintainers": [
+        "toolbox-maintainers@example.com"
+      ],
+      "source": "toolkits/tls-watchtower",
+      "docs_url": "toolkits/tls-watchtower/",
+      "bundle_url": "toolkits/tls-watchtower/bundle.zip",
+      "categories": [
+        "Security",
+        "Monitoring"
       ]
     },
     {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@
 Use this document to record notable changes to published toolkits and repository automation.
 
 ## [Unreleased]
+- Added the TLS Watchtower toolkit with FastAPI, Celery, and React assets for certificate expiry monitoring.
 - Replaced static bundle assets with the dynamic bundler contract
   (`toolkits/<slug>/bundle.zip`).
 - Consolidated documentation into architecture, catalog, toolkit authoring,

--- a/docs/toolkits/tls-watchtower/index.md
+++ b/docs/toolkits/tls-watchtower/index.md
@@ -1,0 +1,55 @@
+---
+title: TLS Watchtower toolkit
+---
+
+<!-- This file is auto-generated from toolkits/tls-watchtower/docs/README.md. -->
+
+# TLS Watchtower toolkit
+
+TLS Watchtower monitors SSL/TLS certificates for a curated list of lab hosts and
+any endpoints that operators register on demand. It ships FastAPI routes for
+managing scans, Celery jobs for scheduled sweeps and retries, and a React panel
+that visualises approaching expirations with red/yellow/green bands.
+
+## Validate before publishing
+
+1. Review `toolkits/tls-watchtower/toolkit.json` for accurate metadata and
+   dashboard copy.
+2. Rebuild the frontend artefact per `docs/BUILDING.md` so
+   `frontend/dist/index.js` aligns with the React source.
+3. Run `scripts/validate-repo.sh` from the repository root; it regenerates the
+   catalog, syncs documentation, and exercises schema validation.
+4. Verify `POST /toolkits/tls-watchtower/scan` accepts a host payload and
+   returns updated expiry metadata.
+5. Confirm the seeded hosts `edge-critical.example` and
+   `staging-gateway.example` render with the expected warning and critical
+   severities in the UI.
+6. Record smoke-check notes in `docs/TESTING.md` before publishing the bundle.
+
+## Runtime expectations
+
+- The backend keeps certificate state in memory via
+  `toolkits/tls-watchtower/backend/state.py`, seeding two deterministic hosts so
+  reviewers can validate the UI without external dependencies.
+- `/toolkits/tls-watchtower/hosts` returns the current inventory ordered by time
+  to expiration, while `/toolkits/tls-watchtower/expiry/{host}` surfaces a single
+  record.
+- `POST /toolkits/tls-watchtower/scan` triggers a recomputation for ad-hoc
+  scans, using hashed host values to create deterministic pseudo-expirations for
+  new entries.
+- Celery tasks `tls-watchtower.daily_sweep` and `tls-watchtower.retry_scan`
+  power scheduled sweeps and manual rechecks through the Toolbox job console.
+- The React panel displays aggregated counts, refresh controls, and recent scan
+  history for each host so operators can confirm rotation plans.
+
+## Operator checklist
+
+1. Install the bundle from the Toolbox catalog UI or via the
+   `/toolkits/install` endpoint.
+2. Load the TLS Watchtower panel and confirm the seeded hosts display
+   immediately.
+3. Trigger a manual scan against a new hostname using the REST API and verify it
+   appears in the dashboard.
+4. Queue `tls-watchtower.daily_sweep` from the job console and confirm histories
+   update with the latest timestamps.
+5. Review renewal messaging with stakeholders before acting on any red status.

--- a/toolkits/tls-watchtower/__init__.py
+++ b/toolkits/tls-watchtower/__init__.py
@@ -1,0 +1,1 @@
+"""TLS Watchtower toolkit exposing certificate health monitoring assets."""

--- a/toolkits/tls-watchtower/backend/__init__.py
+++ b/toolkits/tls-watchtower/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend routes for the TLS Watchtower toolkit."""

--- a/toolkits/tls-watchtower/backend/models.py
+++ b/toolkits/tls-watchtower/backend/models.py
@@ -1,0 +1,49 @@
+"""Pydantic models shared across TLS Watchtower backend and worker code."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field, validator
+
+Severity = Literal["ok", "watch", "warning", "critical"]
+
+
+class ScanRequest(BaseModel):
+    """Request payload accepted by the scan endpoint."""
+
+    host: str = Field(..., description="Hostname or FQDN to probe")
+    port: int = Field(443, description="TLS port to probe", ge=1, le=65535)
+    reason: str | None = Field(
+        None,
+        description="Optional context explaining why the scan was requested.",
+    )
+
+
+class HistoryEntry(BaseModel):
+    """Historical record for a prior scan run."""
+
+    scanned_at: datetime = Field(..., description="Timestamp when the scan executed")
+    expires_at: datetime = Field(..., description="Expiry derived during the scan")
+    status: Severity = Field(..., description="Severity evaluated during the scan")
+
+
+class CertificateSnapshot(BaseModel):
+    """Serializable state for a monitored certificate."""
+
+    host: str
+    port: int
+    expires_at: datetime
+    last_scanned_at: datetime
+    days_remaining: int = Field(..., ge=0)
+    status: Severity
+    status_label: str
+    renewal_message: str
+    error: str | None = None
+    history: list[HistoryEntry] = Field(default_factory=list)
+
+    @validator("history", pre=True)
+    def sort_history(cls, value: list[HistoryEntry]) -> list[HistoryEntry]:  # noqa: N805
+        """Ensure history is sorted descending by scan time."""
+
+        return sorted(value, key=lambda entry: entry.scanned_at, reverse=True)

--- a/toolkits/tls-watchtower/backend/routes.py
+++ b/toolkits/tls-watchtower/backend/routes.py
@@ -1,0 +1,34 @@
+"""FastAPI routes for TLS Watchtower certificate monitoring."""
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+from .models import CertificateSnapshot, ScanRequest
+from .state import store
+
+router = APIRouter(prefix="/toolkits/tls-watchtower", tags=["tls-watchtower"])
+
+
+@router.get("/hosts", response_model=list[CertificateSnapshot])
+async def list_hosts() -> list[CertificateSnapshot]:
+    """Return all monitored hosts sorted by time to expiry."""
+
+    return [record.snapshot() for record in store.list_records()]
+
+
+@router.get("/expiry/{host}", response_model=CertificateSnapshot)
+async def get_host_expiry(host: str) -> CertificateSnapshot:
+    """Return certificate details for a specific host."""
+
+    record = store.get_record(host)
+    if not record:
+        raise HTTPException(status_code=404, detail="Host is not currently monitored")
+    return record.snapshot()
+
+
+@router.post("/scan", response_model=CertificateSnapshot)
+async def trigger_scan(payload: ScanRequest) -> CertificateSnapshot:
+    """Trigger an immediate scan for *payload.host*."""
+
+    record = store.scan(payload.host, payload.port, source="api", reason=payload.reason)
+    return record.snapshot()

--- a/toolkits/tls-watchtower/backend/state.py
+++ b/toolkits/tls-watchtower/backend/state.py
@@ -95,12 +95,12 @@ class CertificateStore:
             self._records[host] = record
             return record
 
-    def bulk_scan(self, hosts: Iterable[str]) -> list[CertificateRecord]:
-        """Scan multiple hosts and return updated records."""
+    def bulk_scan(self, targets: Iterable[tuple[str, int]]) -> list[CertificateRecord]:
+        """Scan multiple host/port pairs and return updated records."""
 
         results: list[CertificateRecord] = []
-        for host in hosts:
-            record = self.scan(host, source="scheduled")
+        for host, port in targets:
+            record = self.scan(host, port, source="scheduled")
             results.append(record)
         return results
 

--- a/toolkits/tls-watchtower/docs/BUILDING.md
+++ b/toolkits/tls-watchtower/docs/BUILDING.md
@@ -1,0 +1,27 @@
+# Building TLS Watchtower
+
+1. Install toolkit dependencies in your local environment:
+
+   ```bash
+   npm install
+   ```
+
+   The repository does not bundle a dedicated package.json for community
+   toolkits, so use the Toolbox runtime build tooling when compiling assets.
+
+2. Rebuild the React panel from the toolkit root:
+
+   ```bash
+   npm run build -- --entry toolkits/tls-watchtower/frontend/index.tsx \
+     --outdir toolkits/tls-watchtower/frontend/dist --format esm
+   ```
+
+   Adjust the bundler command to the runtime you use (Vite, esbuild, or the
+   Toolbox-provided builder). The generated file must be written to
+   `frontend/dist/index.js`.
+
+3. Verify the output bundle includes the certificate dashboard and can be loaded
+   by the Toolbox UI without extra polyfills.
+
+4. Run `scripts/validate-repo.sh` after rebuilding to refresh catalog metadata
+   and generated documentation before committing.

--- a/toolkits/tls-watchtower/docs/CHANGELOG.md
+++ b/toolkits/tls-watchtower/docs/CHANGELOG.md
@@ -1,0 +1,8 @@
+# TLS Watchtower changelog
+
+## [0.1.0] - 2025-10-01
+
+- Initial release with seeded lab hosts, deterministic expiry simulator, and
+  React dashboard.
+- Added FastAPI routes for listing, fetching, and scanning certificates.
+- Registered Celery tasks for daily sweeps and manual retries.

--- a/toolkits/tls-watchtower/docs/README.md
+++ b/toolkits/tls-watchtower/docs/README.md
@@ -1,0 +1,49 @@
+# TLS Watchtower toolkit
+
+TLS Watchtower monitors SSL/TLS certificates for a curated list of lab hosts and
+any endpoints that operators register on demand. It ships FastAPI routes for
+managing scans, Celery jobs for scheduled sweeps and retries, and a React panel
+that visualises approaching expirations with red/yellow/green bands.
+
+## Validate before publishing
+
+1. Review `toolkits/tls-watchtower/toolkit.json` for accurate metadata and
+   dashboard copy.
+2. Rebuild the frontend artefact per `docs/BUILDING.md` so
+   `frontend/dist/index.js` aligns with the React source.
+3. Run `scripts/validate-repo.sh` from the repository root; it regenerates the
+   catalog, syncs documentation, and exercises schema validation.
+4. Verify `POST /toolkits/tls-watchtower/scan` accepts a host payload and
+   returns updated expiry metadata.
+5. Confirm the seeded hosts `edge-critical.example` and
+   `staging-gateway.example` render with the expected warning and critical
+   severities in the UI.
+6. Record smoke-check notes in `docs/TESTING.md` before publishing the bundle.
+
+## Runtime expectations
+
+- The backend keeps certificate state in memory via
+  `toolkits/tls-watchtower/backend/state.py`, seeding two deterministic hosts so
+  reviewers can validate the UI without external dependencies.
+- `/toolkits/tls-watchtower/hosts` returns the current inventory ordered by time
+  to expiration, while `/toolkits/tls-watchtower/expiry/{host}` surfaces a single
+  record.
+- `POST /toolkits/tls-watchtower/scan` triggers a recomputation for ad-hoc
+  scans, using hashed host values to create deterministic pseudo-expirations for
+  new entries.
+- Celery tasks `tls-watchtower.daily_sweep` and `tls-watchtower.retry_scan`
+  power scheduled sweeps and manual rechecks through the Toolbox job console.
+- The React panel displays aggregated counts, refresh controls, and recent scan
+  history for each host so operators can confirm rotation plans.
+
+## Operator checklist
+
+1. Install the bundle from the Toolbox catalog UI or via the
+   `/toolkits/install` endpoint.
+2. Load the TLS Watchtower panel and confirm the seeded hosts display
+   immediately.
+3. Trigger a manual scan against a new hostname using the REST API and verify it
+   appears in the dashboard.
+4. Queue `tls-watchtower.daily_sweep` from the job console and confirm histories
+   update with the latest timestamps.
+5. Review renewal messaging with stakeholders before acting on any red status.

--- a/toolkits/tls-watchtower/docs/RELEASE_NOTES.md
+++ b/toolkits/tls-watchtower/docs/RELEASE_NOTES.md
@@ -1,0 +1,10 @@
+# TLS Watchtower release notes
+
+## 0.1.0
+
+- Shipped the initial certificate monitoring toolkit with sample data to aid
+  reviews.
+- Implemented deterministic pseudo-expiry generation for arbitrary hosts so
+  demonstrations remain offline-friendly.
+- Added dashboard summary counters and recent scan history to surface urgency at
+  a glance.

--- a/toolkits/tls-watchtower/docs/TESTING.md
+++ b/toolkits/tls-watchtower/docs/TESTING.md
@@ -1,0 +1,22 @@
+# Testing TLS Watchtower
+
+Use this checklist to capture manual validation notes each time the bundle is
+updated.
+
+## Smoke checks
+
+- [ ] `POST /toolkits/tls-watchtower/scan` with `{ "host": "edge-critical.example" }`
+      returns a critical status and updates the timestamp.
+- [ ] `POST /toolkits/tls-watchtower/scan` with a new hostname returns a
+      deterministic expiry and adds the host to `/hosts` responses.
+- [ ] Trigger `tls-watchtower.daily_sweep` and confirm the seeded hosts keep
+      their expected severity bands.
+- [ ] Load the React panel and verify the critical/warning counters and history
+      list update after a manual scan.
+
+## Observability
+
+- Document log excerpts or screenshots that demonstrate certificate sweeps when
+  running the toolkit against a live Toolbox environment.
+- Capture any follow-up tickets in this file if expiry parsing fails or requires
+  integration with external certificate stores.

--- a/toolkits/tls-watchtower/frontend/dist/index.js
+++ b/toolkits/tls-watchtower/frontend/dist/index.js
@@ -1,0 +1,229 @@
+function getToolkitRuntime() {
+  if (typeof window === "undefined" || !window.__SRE_TOOLKIT_RUNTIME) {
+    throw new Error("SRE Toolkit runtime not injected yet");
+  }
+  return window.__SRE_TOOLKIT_RUNTIME;
+}
+function getReactRuntime() {
+  return getToolkitRuntime().react;
+}
+function apiFetch(path, options) {
+  return getToolkitRuntime().apiFetch(path, options);
+}
+const React = getReactRuntime();
+const { useCallback, useEffect, useMemo, useState } = React;
+const badgePalette = {
+  ok: "var(--color-status-success)",
+  watch: "var(--color-status-information)",
+  warning: "var(--color-status-warning)",
+  critical: "var(--color-status-danger)",
+};
+const containerStyle = {
+  padding: "1.5rem",
+  display: "grid",
+  gap: "1.5rem",
+  color: "var(--color-text-primary)",
+};
+const cardStyle = {
+  padding: "1.25rem",
+  borderRadius: "0.75rem",
+  border: "1px solid var(--color-border-muted)",
+  background: "var(--color-surface-raised)",
+  display: "grid",
+  gap: "0.75rem",
+};
+const listStyle = {
+  display: "grid",
+  gap: "1rem",
+};
+const historyListStyle = {
+  margin: 0,
+  paddingLeft: "1.1rem",
+  display: "grid",
+  gap: "0.25rem",
+};
+function StatusBadge(props) {
+  const background = badgePalette[props.status] || "var(--color-status-information)";
+  return React.createElement(
+    "span",
+    {
+      style: {
+        alignSelf: "flex-start",
+        padding: "0.25rem 0.6rem",
+        borderRadius: "999px",
+        fontSize: "0.75rem",
+        fontWeight: 600,
+        color: "var(--color-surface-primary)",
+        background,
+      },
+    },
+    props.label,
+  );
+}
+function formatDistance(daysRemaining) {
+  if (daysRemaining === 0) {
+    return "expires today";
+  }
+  if (daysRemaining === 1) {
+    return "1 day remaining";
+  }
+  return `${daysRemaining} days remaining`;
+}
+async function loadHosts() {
+  return apiFetch("/toolkits/tls-watchtower/hosts");
+}
+const TlsWatchtowerPanel = () => {
+  const [hosts, setHosts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const fetchHosts = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await loadHosts();
+      setHosts(Array.isArray(data) ? data : []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to load hosts");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+  useEffect(() => {
+    fetchHosts();
+  }, [fetchHosts]);
+  const criticalCount = useMemo(
+    () => hosts.filter((item) => item.status === "critical").length,
+    [hosts],
+  );
+  const warningCount = useMemo(
+    () => hosts.filter((item) => item.status === "warning").length,
+    [hosts],
+  );
+  return React.createElement(
+    "section",
+    { style: containerStyle },
+    React.createElement(
+      "header",
+      { style: { display: "grid", gap: "0.25rem" } },
+      React.createElement("h1", { style: { margin: 0 } }, "TLS Watchtower"),
+      React.createElement(
+        "p",
+        { style: { margin: 0, color: "var(--color-text-secondary)" } },
+        "Track certificate expirations across self-contained lab hosts with deterministic sample data.",
+      ),
+    ),
+    React.createElement(
+      "div",
+      { style: { display: "flex", gap: "1rem", flexWrap: "wrap" } },
+      React.createElement(
+        "div",
+        { style: { minWidth: "12rem" } },
+        React.createElement("strong", { style: { fontSize: "2rem" } }, criticalCount),
+        React.createElement(
+          "div",
+          { style: { color: "var(--color-text-secondary)" } },
+          "critical expirations",
+        ),
+      ),
+      React.createElement(
+        "div",
+        { style: { minWidth: "12rem" } },
+        React.createElement("strong", { style: { fontSize: "2rem" } }, warningCount),
+        React.createElement(
+          "div",
+          { style: { color: "var(--color-text-secondary)" } },
+          "warning expirations",
+        ),
+      ),
+    ),
+    React.createElement(
+      "div",
+      { style: { display: "flex", gap: "0.75rem", alignItems: "center" } },
+      React.createElement(
+        "button",
+        {
+          type: "button",
+          className: "sre-button",
+          onClick: () => fetchHosts(),
+          disabled: loading,
+        },
+        loading ? "Refreshing" : "Refresh",
+      ),
+      error
+        ? React.createElement(
+            "span",
+            { style: { color: "var(--color-status-danger)" } },
+            error,
+          )
+        : null,
+    ),
+    React.createElement(
+      "div",
+      { style: listStyle },
+      loading
+        ? React.createElement("div", null, "Loading certificate data…")
+        : hosts.length === 0
+        ? React.createElement("div", null, "No hosts registered.")
+        : hosts.map((host) => {
+            const lastScanned = new Date(host.last_scanned_at).toLocaleString();
+            const historyItems = Array.isArray(host.history) ? host.history.slice(0, 4) : [];
+            return React.createElement(
+              "article",
+              { key: host.host, style: cardStyle },
+              React.createElement(
+                "div",
+                {
+                  style: {
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "baseline",
+                    gap: "1rem",
+                  },
+                },
+                React.createElement(
+                  "div",
+                  null,
+                  React.createElement("h2", { style: { margin: 0 } }, host.host),
+                  React.createElement(
+                    "p",
+                    { style: { margin: "0.25rem 0 0", color: "var(--color-text-secondary)" } },
+                    `${formatDistance(host.days_remaining)} · last scanned ${lastScanned}`,
+                  ),
+                ),
+                React.createElement(StatusBadge, {
+                  status: host.status,
+                  label: host.status_label,
+                }),
+              ),
+              React.createElement("p", { style: { margin: 0 } }, host.renewal_message),
+              historyItems.length
+                ? React.createElement(
+                    "div",
+                    null,
+                    React.createElement(
+                      "h3",
+                      { style: { margin: "0 0 0.25rem", fontSize: "0.95rem" } },
+                      "Recent scans",
+                    ),
+                    React.createElement(
+                      "ul",
+                      { style: historyListStyle },
+                      historyItems.map((entry) => {
+                        const scanned = new Date(entry.scanned_at).toLocaleDateString();
+                        const expires = new Date(entry.expires_at).toLocaleDateString();
+                        return React.createElement(
+                          "li",
+                          { key: entry.scanned_at },
+                          `${scanned} → expires ${expires} · ${entry.status}`,
+                        );
+                      }),
+                    ),
+                  )
+                : null,
+            );
+          }),
+    ),
+  );
+};
+export { TlsWatchtowerPanel };
+export default TlsWatchtowerPanel;

--- a/toolkits/tls-watchtower/frontend/index.tsx
+++ b/toolkits/tls-watchtower/frontend/index.tsx
@@ -1,0 +1,180 @@
+import { apiFetch, getReactRuntime } from "./runtime";
+
+const React = getReactRuntime();
+
+export type CertificateSnapshot = {
+  host: string;
+  port: number;
+  expires_at: string;
+  last_scanned_at: string;
+  days_remaining: number;
+  status: "ok" | "watch" | "warning" | "critical";
+  status_label: string;
+  renewal_message: string;
+  error?: string | null;
+  history: Array<{
+    scanned_at: string;
+    expires_at: string;
+    status: "ok" | "watch" | "warning" | "critical";
+  }>;
+};
+
+const badgePalette: Record<CertificateSnapshot["status"], string> = {
+  ok: "var(--color-status-success)",
+  watch: "var(--color-status-information)",
+  warning: "var(--color-status-warning)",
+  critical: "var(--color-status-danger)",
+};
+
+const containerStyle: React.CSSProperties = {
+  padding: "1.5rem",
+  display: "grid",
+  gap: "1.5rem",
+  color: "var(--color-text-primary)",
+};
+
+const cardStyle: React.CSSProperties = {
+  padding: "1.25rem",
+  borderRadius: "0.75rem",
+  border: "1px solid var(--color-border-muted)",
+  background: "var(--color-surface-raised)",
+  display: "grid",
+  gap: "0.75rem",
+};
+
+const listStyle: React.CSSProperties = {
+  display: "grid",
+  gap: "1rem",
+};
+
+const historyListStyle: React.CSSProperties = {
+  margin: 0,
+  paddingLeft: "1.1rem",
+  display: "grid",
+  gap: "0.25rem",
+};
+
+function StatusBadge({ status, label }: { status: CertificateSnapshot["status"]; label: string }) {
+  const background = badgePalette[status] ?? "var(--color-status-information)";
+  const style: React.CSSProperties = {
+    alignSelf: "flex-start",
+    padding: "0.25rem 0.6rem",
+    borderRadius: "999px",
+    fontSize: "0.75rem",
+    fontWeight: 600,
+    color: "var(--color-surface-primary)",
+    background,
+  };
+
+  return <span style={style}>{label}</span>;
+}
+
+function formatDistance(daysRemaining: number) {
+  if (daysRemaining === 0) {
+    return "expires today";
+  }
+  if (daysRemaining === 1) {
+    return "1 day remaining";
+  }
+  return `${daysRemaining} days remaining`;
+}
+
+async function loadHosts(): Promise<CertificateSnapshot[]> {
+  const response = await apiFetch<CertificateSnapshot[]>("/toolkits/tls-watchtower/hosts");
+  return response;
+}
+
+export const TlsWatchtowerPanel = () => {
+  const { useCallback, useEffect, useMemo, useState } = React;
+  const [hosts, setHosts] = useState<CertificateSnapshot[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchHosts = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await loadHosts();
+      setHosts(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to load hosts");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchHosts();
+  }, [fetchHosts]);
+
+  const criticalCount = useMemo(() => hosts.filter((item) => item.status === "critical").length, [hosts]);
+  const warningCount = useMemo(() => hosts.filter((item) => item.status === "warning").length, [hosts]);
+
+  return (
+    <section style={containerStyle}>
+      <header style={{ display: "grid", gap: "0.25rem" }}>
+        <h1 style={{ margin: 0 }}>TLS Watchtower</h1>
+        <p style={{ margin: 0, color: "var(--color-text-secondary)" }}>
+          Track certificate expirations across self-contained lab hosts with deterministic sample data.
+        </p>
+      </header>
+
+      <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap" }}>
+        <div style={{ minWidth: "12rem" }}>
+          <strong style={{ fontSize: "2rem" }}>{criticalCount}</strong>
+          <div style={{ color: "var(--color-text-secondary)" }}>critical expirations</div>
+        </div>
+        <div style={{ minWidth: "12rem" }}>
+          <strong style={{ fontSize: "2rem" }}>{warningCount}</strong>
+          <div style={{ color: "var(--color-text-secondary)" }}>warning expirations</div>
+        </div>
+      </div>
+
+      <div style={{ display: "flex", gap: "0.75rem", alignItems: "center" }}>
+        <button type="button" className="sre-button" onClick={() => fetchHosts()} disabled={loading}>
+          {loading ? "Refreshing" : "Refresh"}
+        </button>
+        {error ? <span style={{ color: "var(--color-status-danger)" }}>{error}</span> : null}
+      </div>
+
+      <div style={listStyle}>
+        {loading ? (
+          <div>Loading certificate data…</div>
+        ) : hosts.length === 0 ? (
+          <div>No hosts registered.</div>
+        ) : (
+          hosts.map((host) => (
+            <article key={host.host} style={cardStyle}>
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: "1rem" }}>
+                <div>
+                  <h2 style={{ margin: 0 }}>{host.host}</h2>
+                  <p style={{ margin: "0.25rem 0 0", color: "var(--color-text-secondary)" }}>
+                    {formatDistance(host.days_remaining)} · last scanned {new Date(host.last_scanned_at).toLocaleString()}
+                  </p>
+                </div>
+                <StatusBadge status={host.status} label={host.status_label} />
+              </div>
+
+              <p style={{ margin: 0 }}>{host.renewal_message}</p>
+
+              {host.history.length > 0 ? (
+                <div>
+                  <h3 style={{ margin: "0 0 0.25rem", fontSize: "0.95rem" }}>Recent scans</h3>
+                  <ul style={historyListStyle}>
+                    {host.history.slice(0, 4).map((entry) => (
+                      <li key={entry.scanned_at}>
+                        {new Date(entry.scanned_at).toLocaleDateString()} → expires {new Date(entry.expires_at).toLocaleDateString()} · {entry.status}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+            </article>
+          ))
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default TlsWatchtowerPanel;

--- a/toolkits/tls-watchtower/frontend/runtime.ts
+++ b/toolkits/tls-watchtower/frontend/runtime.ts
@@ -1,0 +1,33 @@
+import type * as ReactNamespace from 'react'
+import type * as ReactRouterDomNamespace from 'react-router-dom'
+
+export type ToolkitRuntime = {
+  react: typeof ReactNamespace
+  reactRouterDom: typeof ReactRouterDomNamespace
+  apiFetch: (path: string, options?: RequestInit & { json?: unknown }) => Promise<unknown>
+}
+
+declare global {
+  interface Window {
+    __SRE_TOOLKIT_RUNTIME?: ToolkitRuntime
+  }
+}
+
+export function getToolkitRuntime(): ToolkitRuntime {
+  if (typeof window === 'undefined' || !window.__SRE_TOOLKIT_RUNTIME) {
+    throw new Error('SRE Toolkit runtime not injected yet')
+  }
+  return window.__SRE_TOOLKIT_RUNTIME
+}
+
+export function getReactRuntime() {
+  return getToolkitRuntime().react
+}
+
+export function apiFetch<T = unknown>(path: string, options?: RequestInit & { json?: unknown }) {
+  return getToolkitRuntime().apiFetch(path, options) as Promise<T>
+}
+
+export function getReactRouterRuntime() {
+  return getToolkitRuntime().reactRouterDom
+}

--- a/toolkits/tls-watchtower/toolkit.json
+++ b/toolkits/tls-watchtower/toolkit.json
@@ -1,0 +1,36 @@
+{
+  "slug": "tls-watchtower",
+  "name": "TLS Watchtower",
+  "version": "0.1.0",
+  "description": "Certificate health scanner with expiry forecasts and seeded lab hosts.",
+  "base_path": "/toolkits/tls-watchtower",
+  "backend": {
+    "module": "backend.routes",
+    "router_attr": "router"
+  },
+  "worker": {
+    "module": "worker.tasks",
+    "register_attr": "register"
+  },
+  "frontend": {
+    "entry": "frontend/dist/index.js",
+    "source_entry": "frontend/index.tsx"
+  },
+  "docs": {
+    "overview": "docs/README.md"
+  },
+  "catalog": {
+    "categories": ["Security", "Monitoring"],
+    "maintainers": ["toolbox-maintainers@example.com"],
+    "tags": ["tls", "certificates", "observability"],
+    "description": "Monitor SSL/TLS certificate expirations, queue renewals, and surface red/yellow/green dashboards."
+  },
+  "dashboard_cards": [
+    {
+      "title": "Certificate expirations",
+      "body": "Track hosts nearing expiry with Watchtower's red/yellow/green health bands.",
+      "link_text": "Open",
+      "link_href": "/toolkits/tls-watchtower"
+    }
+  ]
+}

--- a/toolkits/tls-watchtower/worker/__init__.py
+++ b/toolkits/tls-watchtower/worker/__init__.py
@@ -1,0 +1,1 @@
+"""Celery tasks for TLS Watchtower."""

--- a/toolkits/tls-watchtower/worker/tasks.py
+++ b/toolkits/tls-watchtower/worker/tasks.py
@@ -1,0 +1,25 @@
+"""Celery task registration for TLS Watchtower."""
+from __future__ import annotations
+
+from celery import Celery
+
+from ..backend.state import store
+
+
+def register(app: Celery) -> None:
+    """Register TLS Watchtower tasks with *app*."""
+
+    @app.task(name="tls-watchtower.daily_sweep")
+    def daily_sweep() -> list[dict[str, object]]:
+        """Re-scan all monitored hosts and return snapshots."""
+
+        hosts = [record.host for record in store.list_records()]
+        records = store.bulk_scan(hosts)
+        return [record.snapshot().model_dump() for record in records]
+
+    @app.task(name="tls-watchtower.retry_scan")
+    def retry_scan(host: str, port: int = 443) -> dict[str, object]:
+        """Trigger a targeted retry for *host* and return its snapshot."""
+
+        record = store.scan(host, port, source="retry")
+        return record.snapshot().model_dump()

--- a/toolkits/tls-watchtower/worker/tasks.py
+++ b/toolkits/tls-watchtower/worker/tasks.py
@@ -13,8 +13,8 @@ def register(app: Celery) -> None:
     def daily_sweep() -> list[dict[str, object]]:
         """Re-scan all monitored hosts and return snapshots."""
 
-        hosts = [record.host for record in store.list_records()]
-        records = store.bulk_scan(hosts)
+        targets = [(record.host, record.port) for record in store.list_records()]
+        records = store.bulk_scan(targets)
         return [record.snapshot().model_dump() for record in records]
 
     @app.task(name="tls-watchtower.retry_scan")


### PR DESCRIPTION
## Summary
- add the TLS Watchtower toolkit with FastAPI endpoints, Celery sweep jobs, deterministic certificate state, and a React dashboard
- document the bundle, generate the catalog entry, and refresh the changelog and generated docs
- record the work in the shared TODO backlog and AI progress journal

## Testing
- scripts/validate-repo.sh
- mkdocs build --strict --clean --site-dir site

------
https://chatgpt.com/codex/tasks/task_b_68dcbda089788328ae957da93aca8f78