### PR TITLE
Fix TLS Watchtower API router path mounting

### DIFF
--- a/toolkits/tls-watchtower/backend/routes.py
+++ b/toolkits/tls-watchtower/backend/routes.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, HTTPException
 from .models import CertificateSnapshot, ScanRequest
 from .state import store
 
-router = APIRouter(prefix="/toolkits/tls-watchtower", tags=["tls-watchtower"])
+router = APIRouter(tags=["tls-watchtower"])
 
 
 @router.get("/hosts", response_model=list[CertificateSnapshot])


### PR DESCRIPTION
## Summary
- remove the redundant router prefix so the TLS Watchtower endpoints mount under the configured base path

## Testing
- scripts/validate-repo.sh
- mkdocs build --strict --clean --site-dir site

------
https://chatgpt.com/codex/tasks/task_b_68df56cbe0cc832895b3584910ef4550