### PR TITLE
Add host management UI and API to TLS Watchtower

### DIFF
--- a/docs/toolkits/tls-watchtower/index.md
+++ b/docs/toolkits/tls-watchtower/index.md
@@ -32,8 +32,10 @@ that visualises approaching expirations with red/yellow/green bands.
   `toolkits/tls-watchtower/backend/state.py`, seeding two deterministic hosts so
   reviewers can validate the UI without external dependencies.
 - `/toolkits/tls-watchtower/hosts` returns the current inventory ordered by time
-  to expiration, while `/toolkits/tls-watchtower/expiry/{host}` surfaces a single
-  record.
+  to expiration. The same endpoint now accepts `POST` requests to register new
+  hosts and `PUT /toolkits/tls-watchtower/hosts/{host}` to edit existing
+  entries, matching the dashboard's add/edit controls.
+- `/toolkits/tls-watchtower/expiry/{host}` surfaces a single record.
 - `POST /toolkits/tls-watchtower/scan` triggers a recomputation for ad-hoc
   scans, using hashed host values to create deterministic pseudo-expirations for
   new entries.

--- a/toolkits/tls-watchtower/backend/models.py
+++ b/toolkits/tls-watchtower/backend/models.py
@@ -20,6 +20,38 @@ class ScanRequest(BaseModel):
     )
 
 
+class HostRegistration(BaseModel):
+    """Payload used to register a new endpoint for monitoring."""
+
+    host: str = Field(..., min_length=1, max_length=255, description="Hostname or FQDN")
+    port: int = Field(443, ge=1, le=65535, description="TLS port to probe")
+
+    @validator("host")
+    def normalise_host(cls, value: str) -> str:  # noqa: N805
+        """Trim whitespace from supplied hostnames."""
+
+        trimmed = value.strip()
+        if not trimmed:
+            raise ValueError("host must not be empty")
+        return trimmed
+
+
+class HostUpdate(BaseModel):
+    """Payload accepted when editing an existing endpoint."""
+
+    host: str | None = Field(None, min_length=1, max_length=255, description="Updated hostname")
+    port: int | None = Field(None, ge=1, le=65535, description="Updated port")
+
+    @validator("host")
+    def normalise_host(cls, value: str | None) -> str | None:  # noqa: N805
+        if value is None:
+            return value
+        trimmed = value.strip()
+        if not trimmed:
+            raise ValueError("host must not be empty")
+        return trimmed
+
+
 class HistoryEntry(BaseModel):
     """Historical record for a prior scan run."""
 

--- a/toolkits/tls-watchtower/docs/README.md
+++ b/toolkits/tls-watchtower/docs/README.md
@@ -26,8 +26,10 @@ that visualises approaching expirations with red/yellow/green bands.
   `toolkits/tls-watchtower/backend/state.py`, seeding two deterministic hosts so
   reviewers can validate the UI without external dependencies.
 - `/toolkits/tls-watchtower/hosts` returns the current inventory ordered by time
-  to expiration, while `/toolkits/tls-watchtower/expiry/{host}` surfaces a single
-  record.
+  to expiration. The same endpoint now accepts `POST` requests to register new
+  hosts and `PUT /toolkits/tls-watchtower/hosts/{host}` to edit existing
+  entries, matching the dashboard's add/edit controls.
+- `/toolkits/tls-watchtower/expiry/{host}` surfaces a single record.
 - `POST /toolkits/tls-watchtower/scan` triggers a recomputation for ad-hoc
   scans, using hashed host values to create deterministic pseudo-expirations for
   new entries.

--- a/toolkits/tls-watchtower/frontend/dist/index.js
+++ b/toolkits/tls-watchtower/frontend/dist/index.js
@@ -18,6 +18,7 @@ const badgePalette = {
   warning: "var(--color-status-warning)",
   critical: "var(--color-status-danger)",
 };
+const statusOrder = ["critical", "warning", "watch", "ok"];
 const containerStyle = {
   padding: "1.5rem",
   display: "grid",
@@ -41,6 +42,76 @@ const historyListStyle = {
   paddingLeft: "1.1rem",
   display: "grid",
   gap: "0.25rem",
+};
+const formCardStyle = {
+  borderRadius: "0.75rem",
+  border: "1px solid var(--color-border-muted)",
+  background: "var(--color-surface-raised)",
+  padding: "1rem",
+  display: "grid",
+  gap: "0.75rem",
+};
+const fieldsetStyle = {
+  display: "grid",
+  gap: "0.25rem",
+  minWidth: "12rem",
+};
+const labelStyle = {
+  fontSize: "0.8rem",
+  fontWeight: 600,
+  color: "var(--color-text-secondary)",
+};
+const inputStyle = {
+  borderRadius: "0.5rem",
+  border: "1px solid var(--color-border-muted)",
+  padding: "0.45rem 0.65rem",
+  fontSize: "0.95rem",
+  background: "var(--color-surface-primary)",
+  color: "var(--color-text-primary)",
+};
+const helperTextStyle = {
+  fontSize: "0.85rem",
+  color: "var(--color-status-danger)",
+};
+const mutedHelperTextStyle = {
+  fontSize: "0.85rem",
+  color: "var(--color-text-secondary)",
+};
+const distributionCardStyle = {
+  borderRadius: "0.75rem",
+  border: "1px solid var(--color-border-muted)",
+  padding: "1rem",
+  background: "var(--color-surface-raised)",
+  display: "grid",
+  gap: "0.5rem",
+};
+const distributionBarStyle = {
+  display: "flex",
+  width: "100%",
+  height: "0.75rem",
+  borderRadius: "999px",
+  overflow: "hidden",
+  background: "var(--color-surface-muted)",
+};
+const distributionDotStyle = {
+  width: "0.5rem",
+  height: "0.5rem",
+  borderRadius: "999px",
+};
+const buttonRowStyle = {
+  display: "flex",
+  gap: "0.5rem",
+  flexWrap: "wrap",
+  alignItems: "center",
+};
+const ghostButtonStyle = {
+  borderRadius: "999px",
+  border: "1px solid var(--color-border-muted)",
+  background: "transparent",
+  padding: "0.4rem 0.85rem",
+  fontWeight: 600,
+  color: "var(--color-text-secondary)",
+  cursor: "pointer",
 };
 function StatusBadge(props) {
   const background = badgePalette[props.status] || "var(--color-status-information)";
@@ -72,10 +143,31 @@ function formatDistance(daysRemaining) {
 async function loadHosts() {
   return apiFetch("/toolkits/tls-watchtower/hosts");
 }
+function createHost(payload) {
+  return apiFetch("/toolkits/tls-watchtower/hosts", {
+    method: "POST",
+    json: payload,
+  });
+}
+function updateHost(originalHost, payload) {
+  return apiFetch(`/toolkits/tls-watchtower/hosts/${encodeURIComponent(originalHost)}`, {
+    method: "PUT",
+    json: payload,
+  });
+}
 const TlsWatchtowerPanel = () => {
   const [hosts, setHosts] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [formHost, setFormHost] = useState("");
+  const [formPort, setFormPort] = useState("443");
+  const [formError, setFormError] = useState(null);
+  const [formSubmitting, setFormSubmitting] = useState(false);
+  const [editingHost, setEditingHost] = useState(null);
+  const [editHostValue, setEditHostValue] = useState("");
+  const [editPortValue, setEditPortValue] = useState("443");
+  const [editError, setEditError] = useState(null);
+  const [editSubmitting, setEditSubmitting] = useState(false);
   const fetchHosts = useCallback(async () => {
     setLoading(true);
     setError(null);
@@ -91,14 +183,273 @@ const TlsWatchtowerPanel = () => {
   useEffect(() => {
     fetchHosts();
   }, [fetchHosts]);
-  const criticalCount = useMemo(
-    () => hosts.filter((item) => item.status === "critical").length,
-    [hosts],
+  const criticalCount = useMemo(() => hosts.filter((item) => item.status === "critical").length, [hosts]);
+  const warningCount = useMemo(() => hosts.filter((item) => item.status === "warning").length, [hosts]);
+  const statusBreakdown = useMemo(() => {
+    return hosts.reduce(
+      (acc, item) => {
+        acc[item.status] += 1;
+        return acc;
+      },
+      { ok: 0, watch: 0, warning: 0, critical: 0 },
+    );
+  }, [hosts]);
+  const totalHosts = hosts.length;
+  const handleAddHost = useCallback(
+    async (event) => {
+      event.preventDefault();
+      const host = formHost.trim();
+      const port = Number(formPort);
+      if (!host) {
+        setFormError("Hostname is required");
+        return;
+      }
+      if (Number.isNaN(port) || port < 1 || port > 65535) {
+        setFormError("Port must be between 1 and 65535");
+        return;
+      }
+      setFormSubmitting(true);
+      setFormError(null);
+      try {
+        await createHost({ host, port });
+        setFormHost("");
+        setFormPort("443");
+        await fetchHosts();
+      } catch (err) {
+        setFormError(err instanceof Error ? err.message : "Unable to add endpoint");
+      } finally {
+        setFormSubmitting(false);
+      }
+    },
+    [fetchHosts, formHost, formPort],
   );
-  const warningCount = useMemo(
-    () => hosts.filter((item) => item.status === "warning").length,
-    [hosts],
+  const handleEditStart = useCallback((snapshot) => {
+    setEditingHost(snapshot.host);
+    setEditHostValue(snapshot.host);
+    setEditPortValue(String(snapshot.port));
+    setEditError(null);
+  }, []);
+  const handleEditCancel = useCallback(() => {
+    setEditingHost(null);
+    setEditHostValue("");
+    setEditPortValue("443");
+    setEditError(null);
+  }, []);
+  const handleEditSubmit = useCallback(
+    async (event) => {
+      event.preventDefault();
+      if (!editingHost) {
+        return;
+      }
+      const host = editHostValue.trim();
+      const port = Number(editPortValue);
+      if (!host) {
+        setEditError("Hostname is required");
+        return;
+      }
+      if (Number.isNaN(port) || port < 1 || port > 65535) {
+        setEditError("Port must be between 1 and 65535");
+        return;
+      }
+      setEditSubmitting(true);
+      setEditError(null);
+      try {
+        await updateHost(editingHost, { host, port });
+        setEditingHost(null);
+        setEditHostValue("");
+        setEditPortValue("443");
+        await fetchHosts();
+      } catch (err) {
+        setEditError(err instanceof Error ? err.message : "Unable to save changes");
+      } finally {
+        setEditSubmitting(false);
+      }
+    },
+    [editHostValue, editPortValue, editingHost, fetchHosts],
   );
+  const distributionContent = totalHosts
+    ? [
+        React.createElement(
+          "div",
+          { style: distributionBarStyle },
+          statusOrder.map((status) => {
+            const count = statusBreakdown[status] || 0;
+            if (!count) {
+              return null;
+            }
+            return React.createElement("span", {
+              key: status,
+              style: {
+                background: badgePalette[status],
+                flexGrow: count,
+                flexBasis: 0,
+              },
+            });
+          }),
+        ),
+        React.createElement(
+          "div",
+          {
+            style: {
+              display: "flex",
+              gap: "1rem",
+              flexWrap: "wrap",
+              fontSize: "0.75rem",
+              color: "var(--color-text-secondary)",
+            },
+          },
+          statusOrder.map((status) =>
+            React.createElement(
+              "span",
+              {
+                key: status,
+                style: { display: "flex", alignItems: "center", gap: "0.4rem" },
+              },
+              React.createElement("span", {
+                style: Object.assign({}, distributionDotStyle, { background: badgePalette[status] }),
+              }),
+              `${statusBreakdown[status] || 0} ${(statusBreakdown[status] || 0) === 1 ? "endpoint" : "endpoints"}`,
+            ),
+          ),
+        ),
+      ]
+    : [React.createElement("div", { style: mutedHelperTextStyle }, "Add an endpoint to populate distribution metrics.")];
+  const hostCards = hosts.map((host) => {
+    const isEditing = editingHost === host.host;
+    const historyItems = Array.isArray(host.history) ? host.history.slice(0, 4) : [];
+    return React.createElement(
+      "article",
+      { key: host.host, style: cardStyle },
+      React.createElement(
+        "div",
+        { style: { display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: "1rem" } },
+        React.createElement(
+          "div",
+          null,
+          React.createElement("h2", { style: { margin: 0 } }, host.host),
+          React.createElement(
+            "p",
+            { style: { margin: "0.25rem 0 0", color: "var(--color-text-secondary)" } },
+            `${formatDistance(host.days_remaining)} · last scanned ${new Date(host.last_scanned_at).toLocaleString()}`,
+          ),
+        ),
+        React.createElement(StatusBadge, {
+          status: host.status,
+          label: host.status_label,
+        }),
+      ),
+      React.createElement("p", { style: { margin: 0 } }, host.renewal_message),
+      isEditing
+        ? React.createElement(
+            "form",
+            { onSubmit: handleEditSubmit, style: { display: "grid", gap: "0.75rem" } },
+            React.createElement(
+              "div",
+              { style: { display: "flex", gap: "1rem", flexWrap: "wrap" } },
+              React.createElement(
+                "label",
+                { style: fieldsetStyle },
+                React.createElement("span", { style: labelStyle }, "Hostname"),
+                React.createElement("input", {
+                  style: inputStyle,
+                  type: "text",
+                  value: editHostValue,
+                  onChange: (event) => setEditHostValue(event.target.value),
+                  disabled: editSubmitting,
+                  required: true,
+                }),
+              ),
+              React.createElement(
+                "label",
+                { style: fieldsetStyle },
+                React.createElement("span", { style: labelStyle }, "Port"),
+                React.createElement("input", {
+                  style: inputStyle,
+                  type: "number",
+                  min: 1,
+                  max: 65535,
+                  value: editPortValue,
+                  onChange: (event) => setEditPortValue(event.target.value),
+                  disabled: editSubmitting,
+                  required: true,
+                }),
+              ),
+            ),
+            React.createElement(
+              "div",
+              { style: buttonRowStyle },
+              React.createElement(
+                "button",
+                { type: "submit", className: "sre-button", disabled: editSubmitting },
+                editSubmitting ? "Saving" : "Save changes",
+              ),
+              React.createElement(
+                "button",
+                {
+                  type: "button",
+                  onClick: handleEditCancel,
+                  style: Object.assign({}, ghostButtonStyle, { opacity: editSubmitting ? 0.6 : 1 }),
+                  disabled: editSubmitting,
+                },
+                "Cancel",
+              ),
+              editError
+                ? React.createElement("span", { style: helperTextStyle }, editError)
+                : React.createElement(
+                    "span",
+                    { style: mutedHelperTextStyle },
+                    "Changes trigger a fresh scan for this endpoint.",
+                  ),
+            ),
+          )
+        : React.createElement(
+            "div",
+            {
+              style: {
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                flexWrap: "wrap",
+                gap: "0.5rem",
+              },
+            },
+            React.createElement(
+              "span",
+              { style: mutedHelperTextStyle },
+              `Port ${host.port}`,
+            ),
+            React.createElement(
+              "button",
+              { type: "button", onClick: () => handleEditStart(host), style: ghostButtonStyle },
+              "Edit endpoint",
+            ),
+          ),
+      historyItems.length
+        ? React.createElement(
+            "div",
+            null,
+            React.createElement(
+              "h3",
+              { style: { margin: "0 0 0.25rem", fontSize: "0.95rem" } },
+              "Recent scans",
+            ),
+            React.createElement(
+              "ul",
+              { style: historyListStyle },
+              historyItems.map((entry) => {
+                const scanned = new Date(entry.scanned_at).toLocaleDateString();
+                const expires = new Date(entry.expires_at).toLocaleDateString();
+                return React.createElement(
+                  "li",
+                  { key: entry.scanned_at },
+                  `${scanned} → expires ${expires} · ${entry.status}`,
+                );
+              }),
+            ),
+          )
+        : null,
+    );
+  });
   return React.createElement(
     "section",
     { style: containerStyle },
@@ -114,26 +465,103 @@ const TlsWatchtowerPanel = () => {
     ),
     React.createElement(
       "div",
-      { style: { display: "flex", gap: "1rem", flexWrap: "wrap" } },
+      { style: { display: "grid", gap: "1rem" } },
       React.createElement(
         "div",
-        { style: { minWidth: "12rem" } },
-        React.createElement("strong", { style: { fontSize: "2rem" } }, criticalCount),
+        { style: { display: "flex", gap: "1rem", flexWrap: "wrap" } },
         React.createElement(
           "div",
-          { style: { color: "var(--color-text-secondary)" } },
-          "critical expirations",
+          { style: { minWidth: "12rem" } },
+          React.createElement("strong", { style: { fontSize: "2rem" } }, criticalCount),
+          React.createElement(
+            "div",
+            { style: { color: "var(--color-text-secondary)" } },
+            "critical expirations",
+          ),
+        ),
+        React.createElement(
+          "div",
+          { style: { minWidth: "12rem" } },
+          React.createElement("strong", { style: { fontSize: "2rem" } }, warningCount),
+          React.createElement(
+            "div",
+            { style: { color: "var(--color-text-secondary)" } },
+            "warning expirations",
+          ),
         ),
       ),
       React.createElement(
         "div",
-        { style: { minWidth: "12rem" } },
-        React.createElement("strong", { style: { fontSize: "2rem" } }, warningCount),
+        { style: distributionCardStyle },
         React.createElement(
           "div",
-          { style: { color: "var(--color-text-secondary)" } },
-          "warning expirations",
+          {
+            style: {
+              fontSize: "0.8rem",
+              fontWeight: 600,
+              color: "var(--color-text-secondary)",
+              textTransform: "uppercase",
+            },
+          },
+          "Inventory distribution",
         ),
+        ...distributionContent,
+      ),
+    ),
+    React.createElement(
+      "form",
+      { style: formCardStyle, onSubmit: handleAddHost },
+      React.createElement(
+        "div",
+        { style: { display: "flex", gap: "1rem", flexWrap: "wrap" } },
+        React.createElement(
+          "label",
+          { style: fieldsetStyle },
+          React.createElement("span", { style: labelStyle }, "Hostname"),
+          React.createElement("input", {
+            style: inputStyle,
+            type: "text",
+            name: "host",
+            autoComplete: "off",
+            placeholder: "example.internal",
+            value: formHost,
+            onChange: (event) => setFormHost(event.target.value),
+            disabled: formSubmitting,
+            required: true,
+          }),
+        ),
+        React.createElement(
+          "label",
+          { style: fieldsetStyle },
+          React.createElement("span", { style: labelStyle }, "Port"),
+          React.createElement("input", {
+            style: inputStyle,
+            type: "number",
+            name: "port",
+            min: 1,
+            max: 65535,
+            value: formPort,
+            onChange: (event) => setFormPort(event.target.value),
+            disabled: formSubmitting,
+            required: true,
+          }),
+        ),
+      ),
+      React.createElement(
+        "div",
+        { style: buttonRowStyle },
+        React.createElement(
+          "button",
+          { type: "submit", className: "sre-button", disabled: formSubmitting },
+          formSubmitting ? "Adding" : "Add endpoint",
+        ),
+        formError
+          ? React.createElement("span", { style: helperTextStyle }, formError)
+          : React.createElement(
+              "span",
+              { style: mutedHelperTextStyle },
+              "New endpoints are scanned immediately after creation.",
+            ),
       ),
     ),
     React.createElement(
@@ -141,21 +569,10 @@ const TlsWatchtowerPanel = () => {
       { style: { display: "flex", gap: "0.75rem", alignItems: "center" } },
       React.createElement(
         "button",
-        {
-          type: "button",
-          className: "sre-button",
-          onClick: () => fetchHosts(),
-          disabled: loading,
-        },
+        { type: "button", className: "sre-button", onClick: () => fetchHosts(), disabled: loading },
         loading ? "Refreshing" : "Refresh",
       ),
-      error
-        ? React.createElement(
-            "span",
-            { style: { color: "var(--color-status-danger)" } },
-            error,
-          )
-        : null,
+      error ? React.createElement("span", { style: { color: "var(--color-status-danger)" } }, error) : null,
     ),
     React.createElement(
       "div",
@@ -163,65 +580,8 @@ const TlsWatchtowerPanel = () => {
       loading
         ? React.createElement("div", null, "Loading certificate data…")
         : hosts.length === 0
-        ? React.createElement("div", null, "No hosts registered.")
-        : hosts.map((host) => {
-            const lastScanned = new Date(host.last_scanned_at).toLocaleString();
-            const historyItems = Array.isArray(host.history) ? host.history.slice(0, 4) : [];
-            return React.createElement(
-              "article",
-              { key: host.host, style: cardStyle },
-              React.createElement(
-                "div",
-                {
-                  style: {
-                    display: "flex",
-                    justifyContent: "space-between",
-                    alignItems: "baseline",
-                    gap: "1rem",
-                  },
-                },
-                React.createElement(
-                  "div",
-                  null,
-                  React.createElement("h2", { style: { margin: 0 } }, host.host),
-                  React.createElement(
-                    "p",
-                    { style: { margin: "0.25rem 0 0", color: "var(--color-text-secondary)" } },
-                    `${formatDistance(host.days_remaining)} · last scanned ${lastScanned}`,
-                  ),
-                ),
-                React.createElement(StatusBadge, {
-                  status: host.status,
-                  label: host.status_label,
-                }),
-              ),
-              React.createElement("p", { style: { margin: 0 } }, host.renewal_message),
-              historyItems.length
-                ? React.createElement(
-                    "div",
-                    null,
-                    React.createElement(
-                      "h3",
-                      { style: { margin: "0 0 0.25rem", fontSize: "0.95rem" } },
-                      "Recent scans",
-                    ),
-                    React.createElement(
-                      "ul",
-                      { style: historyListStyle },
-                      historyItems.map((entry) => {
-                        const scanned = new Date(entry.scanned_at).toLocaleDateString();
-                        const expires = new Date(entry.expires_at).toLocaleDateString();
-                        return React.createElement(
-                          "li",
-                          { key: entry.scanned_at },
-                          `${scanned} → expires ${expires} · ${entry.status}`,
-                        );
-                      }),
-                    ),
-                  )
-                : null,
-            );
-          }),
+          ? React.createElement("div", null, "No hosts registered.")
+          : hostCards,
     ),
   );
 };

--- a/toolkits/tls-watchtower/frontend/index.tsx
+++ b/toolkits/tls-watchtower/frontend/index.tsx
@@ -19,12 +19,16 @@ export type CertificateSnapshot = {
   }>;
 };
 
-const badgePalette: Record<CertificateSnapshot["status"], string> = {
+type Severity = CertificateSnapshot["status"];
+
+const badgePalette: Record<Severity, string> = {
   ok: "var(--color-status-success)",
   watch: "var(--color-status-information)",
   warning: "var(--color-status-warning)",
   critical: "var(--color-status-danger)",
 };
+
+const statusOrder: Severity[] = ["critical", "warning", "watch", "ok"];
 
 const containerStyle: React.CSSProperties = {
   padding: "1.5rem",
@@ -54,7 +58,88 @@ const historyListStyle: React.CSSProperties = {
   gap: "0.25rem",
 };
 
-function StatusBadge({ status, label }: { status: CertificateSnapshot["status"]; label: string }) {
+const formCardStyle: React.CSSProperties = {
+  borderRadius: "0.75rem",
+  border: "1px solid var(--color-border-muted)",
+  background: "var(--color-surface-raised)",
+  padding: "1rem",
+  display: "grid",
+  gap: "0.75rem",
+};
+
+const fieldsetStyle: React.CSSProperties = {
+  display: "grid",
+  gap: "0.25rem",
+  minWidth: "12rem",
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: "0.8rem",
+  fontWeight: 600,
+  color: "var(--color-text-secondary)",
+};
+
+const inputStyle: React.CSSProperties = {
+  borderRadius: "0.5rem",
+  border: "1px solid var(--color-border-muted)",
+  padding: "0.45rem 0.65rem",
+  fontSize: "0.95rem",
+  background: "var(--color-surface-primary)",
+  color: "var(--color-text-primary)",
+};
+
+const helperTextStyle: React.CSSProperties = {
+  fontSize: "0.85rem",
+  color: "var(--color-status-danger)",
+};
+
+const mutedHelperTextStyle: React.CSSProperties = {
+  fontSize: "0.85rem",
+  color: "var(--color-text-secondary)",
+};
+
+const distributionCardStyle: React.CSSProperties = {
+  borderRadius: "0.75rem",
+  border: "1px solid var(--color-border-muted)",
+  padding: "1rem",
+  background: "var(--color-surface-raised)",
+  display: "grid",
+  gap: "0.5rem",
+};
+
+const distributionBarStyle: React.CSSProperties = {
+  display: "flex",
+  width: "100%",
+  height: "0.75rem",
+  borderRadius: "999px",
+  overflow: "hidden",
+  background: "var(--color-surface-muted)",
+};
+
+const distributionDotStyle: React.CSSProperties = {
+  width: "0.5rem",
+  height: "0.5rem",
+  borderRadius: "999px",
+};
+
+const buttonRowStyle: React.CSSProperties = {
+  display: "flex",
+  gap: "0.5rem",
+  flexWrap: "wrap",
+  alignItems: "center",
+};
+
+const ghostButtonStyle: React.CSSProperties = {
+  borderRadius: "999px",
+  border: "1px solid var(--color-border-muted)",
+  background: "transparent",
+  padding: "0.4rem 0.85rem",
+  fontWeight: 600,
+  color: "var(--color-text-secondary)",
+  cursor: "pointer",
+};
+
+function StatusBadge({ status, label }: { status: Severity; label: string }) {
   const background = badgePalette[status] ?? "var(--color-status-information)";
   const style: React.CSSProperties = {
     alignSelf: "flex-start",
@@ -84,11 +169,37 @@ async function loadHosts(): Promise<CertificateSnapshot[]> {
   return response;
 }
 
+async function createHost(payload: { host: string; port: number }) {
+  return apiFetch<CertificateSnapshot>("/toolkits/tls-watchtower/hosts", {
+    method: "POST",
+    json: payload,
+  });
+}
+
+async function updateHost(originalHost: string, payload: { host: string; port: number }) {
+  return apiFetch<CertificateSnapshot>(`/toolkits/tls-watchtower/hosts/${encodeURIComponent(originalHost)}`, {
+    method: "PUT",
+    json: payload,
+  });
+}
+
 export const TlsWatchtowerPanel = () => {
   const { useCallback, useEffect, useMemo, useState } = React;
+
   const [hosts, setHosts] = useState<CertificateSnapshot[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  const [formHost, setFormHost] = useState("");
+  const [formPort, setFormPort] = useState("443");
+  const [formError, setFormError] = useState<string | null>(null);
+  const [formSubmitting, setFormSubmitting] = useState(false);
+
+  const [editingHost, setEditingHost] = useState<string | null>(null);
+  const [editHostValue, setEditHostValue] = useState("");
+  const [editPortValue, setEditPortValue] = useState("443");
+  const [editError, setEditError] = useState<string | null>(null);
+  const [editSubmitting, setEditSubmitting] = useState(false);
 
   const fetchHosts = useCallback(async () => {
     setLoading(true);
@@ -109,6 +220,99 @@ export const TlsWatchtowerPanel = () => {
 
   const criticalCount = useMemo(() => hosts.filter((item) => item.status === "critical").length, [hosts]);
   const warningCount = useMemo(() => hosts.filter((item) => item.status === "warning").length, [hosts]);
+  const statusBreakdown = useMemo(() => {
+    return hosts.reduce(
+      (acc, item) => {
+        acc[item.status] += 1;
+        return acc;
+      },
+      { ok: 0, watch: 0, warning: 0, critical: 0 } as Record<Severity, number>,
+    );
+  }, [hosts]);
+  const totalHosts = hosts.length;
+
+  const handleAddHost = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const host = formHost.trim();
+      const port = Number(formPort);
+
+      if (!host) {
+        setFormError("Hostname is required");
+        return;
+      }
+      if (Number.isNaN(port) || port < 1 || port > 65535) {
+        setFormError("Port must be between 1 and 65535");
+        return;
+      }
+
+      setFormSubmitting(true);
+      setFormError(null);
+
+      try {
+        await createHost({ host, port });
+        setFormHost("");
+        setFormPort("443");
+        await fetchHosts();
+      } catch (err) {
+        setFormError(err instanceof Error ? err.message : "Unable to add endpoint");
+      } finally {
+        setFormSubmitting(false);
+      }
+    },
+    [fetchHosts, formHost, formPort],
+  );
+
+  const handleEditStart = useCallback((snapshot: CertificateSnapshot) => {
+    setEditingHost(snapshot.host);
+    setEditHostValue(snapshot.host);
+    setEditPortValue(String(snapshot.port));
+    setEditError(null);
+  }, []);
+
+  const handleEditCancel = useCallback(() => {
+    setEditingHost(null);
+    setEditHostValue("");
+    setEditPortValue("443");
+    setEditError(null);
+  }, []);
+
+  const handleEditSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (!editingHost) {
+        return;
+      }
+
+      const host = editHostValue.trim();
+      const port = Number(editPortValue);
+
+      if (!host) {
+        setEditError("Hostname is required");
+        return;
+      }
+      if (Number.isNaN(port) || port < 1 || port > 65535) {
+        setEditError("Port must be between 1 and 65535");
+        return;
+      }
+
+      setEditSubmitting(true);
+      setEditError(null);
+
+      try {
+        await updateHost(editingHost, { host, port });
+        setEditingHost(null);
+        setEditHostValue("");
+        setEditPortValue("443");
+        await fetchHosts();
+      } catch (err) {
+        setEditError(err instanceof Error ? err.message : "Unable to save changes");
+      } finally {
+        setEditSubmitting(false);
+      }
+    },
+    [editHostValue, editPortValue, editingHost, fetchHosts],
+  );
 
   return (
     <section style={containerStyle}>
@@ -119,16 +323,96 @@ export const TlsWatchtowerPanel = () => {
         </p>
       </header>
 
-      <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap" }}>
-        <div style={{ minWidth: "12rem" }}>
-          <strong style={{ fontSize: "2rem" }}>{criticalCount}</strong>
-          <div style={{ color: "var(--color-text-secondary)" }}>critical expirations</div>
+      <div style={{ display: "grid", gap: "1rem" }}>
+        <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap" }}>
+          <div style={{ minWidth: "12rem" }}>
+            <strong style={{ fontSize: "2rem" }}>{criticalCount}</strong>
+            <div style={{ color: "var(--color-text-secondary)" }}>critical expirations</div>
+          </div>
+          <div style={{ minWidth: "12rem" }}>
+            <strong style={{ fontSize: "2rem" }}>{warningCount}</strong>
+            <div style={{ color: "var(--color-text-secondary)" }}>warning expirations</div>
+          </div>
         </div>
-        <div style={{ minWidth: "12rem" }}>
-          <strong style={{ fontSize: "2rem" }}>{warningCount}</strong>
-          <div style={{ color: "var(--color-text-secondary)" }}>warning expirations</div>
+
+        <div style={distributionCardStyle}>
+          <div style={{ fontSize: "0.8rem", fontWeight: 600, color: "var(--color-text-secondary)", textTransform: "uppercase" }}>
+            Inventory distribution
+          </div>
+          {totalHosts > 0 ? (
+            <>
+              <div style={distributionBarStyle}>
+                {statusOrder.map((status) => {
+                  const count = statusBreakdown[status];
+                  if (count === 0) {
+                    return null;
+                  }
+
+                  return (
+                    <span
+                      key={status}
+                      style={{
+                        background: badgePalette[status],
+                        flexGrow: count,
+                        flexBasis: 0,
+                      }}
+                    />
+                  );
+                })}
+              </div>
+              <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap", fontSize: "0.75rem", color: "var(--color-text-secondary)" }}>
+                {statusOrder.map((status) => (
+                  <span key={status} style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
+                    <span style={{ ...distributionDotStyle, background: badgePalette[status] }} />
+                    {statusBreakdown[status]} {statusBreakdown[status] === 1 ? "endpoint" : "endpoints"}
+                  </span>
+                ))}
+              </div>
+            </>
+          ) : (
+            <div style={mutedHelperTextStyle}>Add an endpoint to populate distribution metrics.</div>
+          )}
         </div>
       </div>
+
+      <form style={formCardStyle} onSubmit={handleAddHost}>
+        <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap" }}>
+          <label style={fieldsetStyle}>
+            <span style={labelStyle}>Hostname</span>
+            <input
+              style={inputStyle}
+              type="text"
+              name="host"
+              autoComplete="off"
+              placeholder="example.internal"
+              value={formHost}
+              onChange={(event) => setFormHost(event.target.value)}
+              disabled={formSubmitting}
+              required
+            />
+          </label>
+          <label style={fieldsetStyle}>
+            <span style={labelStyle}>Port</span>
+            <input
+              style={inputStyle}
+              type="number"
+              name="port"
+              min={1}
+              max={65535}
+              value={formPort}
+              onChange={(event) => setFormPort(event.target.value)}
+              disabled={formSubmitting}
+              required
+            />
+          </label>
+        </div>
+        <div style={buttonRowStyle}>
+          <button type="submit" className="sre-button" disabled={formSubmitting}>
+            {formSubmitting ? "Adding" : "Add endpoint"}
+          </button>
+          {formError ? <span style={helperTextStyle}>{formError}</span> : <span style={mutedHelperTextStyle}>New endpoints are scanned immediately after creation.</span>}
+        </div>
+      </form>
 
       <div style={{ display: "flex", gap: "0.75rem", alignItems: "center" }}>
         <button type="button" className="sre-button" onClick={() => fetchHosts()} disabled={loading}>
@@ -143,34 +427,93 @@ export const TlsWatchtowerPanel = () => {
         ) : hosts.length === 0 ? (
           <div>No hosts registered.</div>
         ) : (
-          hosts.map((host) => (
-            <article key={host.host} style={cardStyle}>
-              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: "1rem" }}>
-                <div>
-                  <h2 style={{ margin: 0 }}>{host.host}</h2>
-                  <p style={{ margin: "0.25rem 0 0", color: "var(--color-text-secondary)" }}>
-                    {formatDistance(host.days_remaining)} · last scanned {new Date(host.last_scanned_at).toLocaleString()}
-                  </p>
+          hosts.map((host) => {
+            const isEditing = editingHost === host.host;
+            return (
+              <article key={host.host} style={cardStyle}>
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: "1rem" }}>
+                  <div>
+                    <h2 style={{ margin: 0 }}>{host.host}</h2>
+                    <p style={{ margin: "0.25rem 0 0", color: "var(--color-text-secondary)" }}>
+                      {formatDistance(host.days_remaining)} · last scanned {new Date(host.last_scanned_at).toLocaleString()}
+                    </p>
+                  </div>
+                  <StatusBadge status={host.status} label={host.status_label} />
                 </div>
-                <StatusBadge status={host.status} label={host.status_label} />
-              </div>
 
-              <p style={{ margin: 0 }}>{host.renewal_message}</p>
+                <p style={{ margin: 0 }}>{host.renewal_message}</p>
 
-              {host.history.length > 0 ? (
-                <div>
-                  <h3 style={{ margin: "0 0 0.25rem", fontSize: "0.95rem" }}>Recent scans</h3>
-                  <ul style={historyListStyle}>
-                    {host.history.slice(0, 4).map((entry) => (
-                      <li key={entry.scanned_at}>
-                        {new Date(entry.scanned_at).toLocaleDateString()} → expires {new Date(entry.expires_at).toLocaleDateString()} · {entry.status}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              ) : null}
-            </article>
-          ))
+                {isEditing ? (
+                  <form onSubmit={handleEditSubmit} style={{ display: "grid", gap: "0.75rem" }}>
+                    <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap" }}>
+                      <label style={fieldsetStyle}>
+                        <span style={labelStyle}>Hostname</span>
+                        <input
+                          style={inputStyle}
+                          type="text"
+                          value={editHostValue}
+                          onChange={(event) => setEditHostValue(event.target.value)}
+                          disabled={editSubmitting}
+                          required
+                        />
+                      </label>
+                      <label style={fieldsetStyle}>
+                        <span style={labelStyle}>Port</span>
+                        <input
+                          style={inputStyle}
+                          type="number"
+                          min={1}
+                          max={65535}
+                          value={editPortValue}
+                          onChange={(event) => setEditPortValue(event.target.value)}
+                          disabled={editSubmitting}
+                          required
+                        />
+                      </label>
+                    </div>
+                    <div style={buttonRowStyle}>
+                      <button type="submit" className="sre-button" disabled={editSubmitting}>
+                        {editSubmitting ? "Saving" : "Save changes"}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={handleEditCancel}
+                        style={{ ...ghostButtonStyle, opacity: editSubmitting ? 0.6 : 1 }}
+                        disabled={editSubmitting}
+                      >
+                        Cancel
+                      </button>
+                      {editError ? <span style={helperTextStyle}>{editError}</span> : <span style={mutedHelperTextStyle}>Changes trigger a fresh scan for this endpoint.</span>}
+                    </div>
+                  </form>
+                ) : (
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: "0.5rem" }}>
+                    <span style={mutedHelperTextStyle}>Port {host.port}</span>
+                    <button
+                      type="button"
+                      onClick={() => handleEditStart(host)}
+                      style={ghostButtonStyle}
+                    >
+                      Edit endpoint
+                    </button>
+                  </div>
+                )}
+
+                {host.history.length > 0 ? (
+                  <div>
+                    <h3 style={{ margin: "0 0 0.25rem", fontSize: "0.95rem" }}>Recent scans</h3>
+                    <ul style={historyListStyle}>
+                      {host.history.slice(0, 4).map((entry) => (
+                        <li key={entry.scanned_at}>
+                          {new Date(entry.scanned_at).toLocaleDateString()} → expires {new Date(entry.expires_at).toLocaleDateString()} · {entry.status}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+              </article>
+            );
+          })
         )}
       </div>
     </section>


### PR DESCRIPTION
## Summary
- add REST payloads and routes so TLS Watchtower can register and update monitored hosts
- teach the certificate store to handle host additions, renames, and port edits while keeping recent history
- refresh the dashboard with add/edit forms, a distribution graphic, and update the toolkit docs accordingly

## Testing
- scripts/validate-repo.sh
- mkdocs build --strict --clean --site-dir site

------
https://chatgpt.com/codex/tasks/task_b_68df594c0afc83289fdcc1bb380a60b3